### PR TITLE
FTSK-43: 문제 유형 선택 기능 추가 및 이전 버튼 클릭 시 선택 유지 적용

### DIFF
--- a/src/features/create/innerPages/ChooseType.tsx
+++ b/src/features/create/innerPages/ChooseType.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect } from 'react';
+import Title from '@/features/create/components/Title';
+import StyledSubTitle from '@/features/create/components/Subtitle';
+import styled from '@emotion/styled';
+import Spacer from '@/shared/components/Spacer';
+import { ListChecks, Binary, PenLine } from 'lucide-react';
+
+interface ChooseTypeProps {
+  selectedType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT' | null;
+  onValidChange: (isValid: boolean) => void;
+  onSelectType: (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT') => void;
+}
+
+const InfoContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  gap: 12px;
+`;
+
+const RadioCard = styled.label<{ selected: boolean }>`
+  flex: 1;
+  background-color: ${({ theme, selected }) =>
+    selected ? theme.colors.semantic.primary : theme.colors.background.foreground};
+  border-radius: ${({ theme }) => theme.radius.radius2};
+  border: 2px solid
+    ${({ theme, selected }) =>
+      selected ? theme.colors.semantic.primary : theme.colors.border.border1};
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.semantic.primary};
+  }
+`;
+
+const HiddenRadio = styled.input`
+  display: none;
+`;
+
+const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+`;
+
+const InfoTitle = styled.h3<{ selected: boolean }>`
+  font-size: ${({ theme }) => theme.typography.body3Bold.fontSize};
+  color: ${({ theme, selected }) => (selected ? 'white' : theme.colors.text.default)};
+`;
+
+const InfoContent = styled.p<{ selected: boolean }>`
+  font-size: ${({ theme }) => theme.typography.body2Regular.fontSize};
+  color: ${({ theme, selected }) => (selected ? 'white' : theme.colors.gray.gray6)};
+`;
+
+const ChooseType: React.FC<ChooseTypeProps> = ({ selectedType, onValidChange, onSelectType }) => {
+  useEffect(() => {
+    onValidChange(!!selectedType);
+  }, [selectedType]);
+
+  const handleSelect = (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT') => {
+    onSelectType(type);
+  };
+
+  const infoData = [
+    {
+      id: 'MULTIPLE_CHOICE' as const,
+      title: '객관식',
+      content: '4개 선택지 중 정답 선택',
+      icon: ListChecks,
+    },
+    {
+      id: 'TRUE_FALSE' as const,
+      title: '참/거짓',
+      content: '참 또는 거짓 중 선택',
+      icon: Binary,
+    },
+    {
+      id: 'SHORT' as const,
+      title: '단답형',
+      content: '짧은 답변 직접 작성',
+      icon: PenLine,
+    },
+  ];
+
+  return (
+    <>
+      <Title>문제 유형을 선택하세요</Title>
+      <StyledSubTitle>어떤 형태의 문제를 생성할까요</StyledSubTitle>
+      <Spacer height="12px" />
+      <InfoContainer>
+        {infoData.map(({ id, title, content, icon: IconComponent }) => {
+          const selected = selectedType === id;
+          const iconColor = selected ? 'white' : 'currentColor';
+
+          return (
+            <RadioCard key={id} selected={selected}>
+              <HiddenRadio
+                type="radio"
+                name="questionType"
+                value={id}
+                checked={selected}
+                onChange={() => handleSelect(id)}
+              />
+              <TitleContainer>
+                <IconComponent size={20} color={iconColor} />
+                <InfoTitle selected={selected}>{title}</InfoTitle>
+              </TitleContainer>
+              <InfoContent selected={selected}>{content}</InfoContent>
+            </RadioCard>
+          );
+        })}
+      </InfoContainer>
+      <Spacer height="20px" />
+    </>
+  );
+};
+
+export default ChooseType;

--- a/src/features/create/innerPages/CreateSummary.tsx
+++ b/src/features/create/innerPages/CreateSummary.tsx
@@ -4,9 +4,10 @@ import StyledSubTitle from '@/features/create/components/Subtitle';
 import styled from '@emotion/styled';
 import Spacer from '@/shared/components/Spacer';
 
-interface Step2Props {
+interface CreateSummaryProps {
   onValidChange: (isValid: boolean) => void;
   selectedFile: { id: string; name: string | null } | null;
+  questionType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT' | null;
 }
 
 const InfoContainer = styled.div`
@@ -20,12 +21,11 @@ const SettingInfoBox = styled.div`
   background-color: ${({ theme }) => theme.colors.background.foreground};
   border-radius: ${({ theme }) => theme.radius.radius2};
   border: 1px solid ${({ theme }) => theme.colors.border.border1};
-  padding: 10px 15px;
+  padding: 15px;
   flex: 1;
   display: flex;
   flex-direction: column;
   min-width: 0;
-  padding: 15px;
 `;
 
 const InfoTitle = styled.h3`
@@ -48,10 +48,24 @@ const InfoSpan = styled.span`
   text-overflow: ellipsis;
 `;
 
-const CreateSummary: React.FC<Step2Props> = ({ onValidChange, selectedFile }) => {
+const CreateSummary: React.FC<CreateSummaryProps> = ({
+  onValidChange,
+  selectedFile,
+  questionType,
+}) => {
   useEffect(() => {
     onValidChange(true);
   }, []);
+
+  const questionTypeDetails = {
+    MULTIPLE_CHOICE: { content: '객관식', description: '4지 선다형' },
+    TRUE_FALSE: { content: '참/거짓', description: '참 또는 거짓 중 선택' },
+    SHORT: { content: '단답형', description: '짧은 답변 직접 작성' },
+  };
+
+  const selectedTypeDetails = questionType
+    ? questionTypeDetails[questionType]
+    : { content: '미선택', description: '문제 유형을 선택해주세요.' };
 
   const infoData = [
     {
@@ -59,15 +73,11 @@ const CreateSummary: React.FC<Step2Props> = ({ onValidChange, selectedFile }) =>
       content: '1개',
       description: selectedFile?.name ?? '선택된 파일이 없습니다.',
     },
-    {
-      title: '문제 개수',
-      content: '10문제',
-      description: 'PDF 내용으로만',
-    },
+    { title: '문제 개수', content: '10문제', description: 'PDF 내용으로만' },
     {
       title: '문제 유형',
-      content: '객관식',
-      description: '4지 선다형',
+      content: selectedTypeDetails.content,
+      description: selectedTypeDetails.description,
     },
   ];
 

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -31,7 +31,7 @@ type CreateProps = {
 };
 
 const Create = () => {
-  const stepLabels = ['PDF 선택', '문제유형', '생성요약', '생성하기'];
+  const stepLabels = ['PDF 선택', '문제 유형', '생성 요약', '생성하기'];
   const [currentStep, setCurrentStep] = useState(1);
   const [selectedFile, setSelectedFile] = useState<{ id: string; name: string } | null>(null);
 


### PR DESCRIPTION
## PR 설명

- 문제생성 페이지에서 문제 유형 선택 기능을 적용한 PR입니다.

## 작업 상세 내용

- 문제 유형 선택 기능 활성화
- 이전으로 갈 경우 예전 선택 유지 기능 추가

## 기타사항 / 참고사항

- API가 나왔을 때 객관식/참거짓/단답형에 대한 type 코드는 바꿔야 할 수 있습니다.
- 현재는 객관식만 정상작동합니다.
