### PR TITLE
FTSK-44: 문제 생성 페이지 hr 쏠림 현상 개선, 프로그래스바 버그 수정, 공통 항목 리팩토링

### DIFF
--- a/src/features/create/components/NavigationButtons.tsx
+++ b/src/features/create/components/NavigationButtons.tsx
@@ -13,7 +13,7 @@ const Hr = styled.hr`
   height: 1px;
   background-color: ${({ theme }) => theme.colors.border.border0};
   border: none;
-  margin: ${({ theme }) => theme.spacing.spacing4};
+  margin: ${({ theme }) => `${theme.spacing.spacing4} 0`};
 `;
 
 const ButtonBox = styled.div`

--- a/src/features/create/constants/questionTypeConstants.ts
+++ b/src/features/create/constants/questionTypeConstants.ts
@@ -1,0 +1,26 @@
+import { ListChecks, Binary, PenLine } from 'lucide-react';
+
+export type QuestionType = 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER';
+
+export const QUESTION_TYPE_DATA = [
+  {
+    id: 'MULTIPLE_CHOICE' as const,
+    title: '객관식',
+    description: '4개 선택지 중 정답 선택',
+    icon: ListChecks,
+  },
+  {
+    id: 'TRUE_FALSE' as const,
+    title: '참/거짓',
+    description: '참 또는 거짓 중 선택',
+    icon: Binary,
+  },
+  {
+    id: 'SHORT_ANSWER' as const,
+    title: '단답형',
+    description: '짧은 답변 직접 작성',
+    icon: PenLine,
+  },
+];
+
+export const QUESTION_TYPE_MAP = new Map(QUESTION_TYPE_DATA.map((item) => [item.id, item]));

--- a/src/features/create/innerPages/ChooseType.tsx
+++ b/src/features/create/innerPages/ChooseType.tsx
@@ -6,9 +6,9 @@ import Spacer from '@/shared/components/Spacer';
 import { ListChecks, Binary, PenLine } from 'lucide-react';
 
 interface ChooseTypeProps {
-  selectedType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT' | null;
+  selectedType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER' | null;
   onValidChange: (isValid: boolean) => void;
-  onSelectType: (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT') => void;
+  onSelectType: (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER') => void;
 }
 
 const InfoContainer = styled.div`
@@ -63,7 +63,7 @@ const ChooseType: React.FC<ChooseTypeProps> = ({ selectedType, onValidChange, on
     onValidChange(!!selectedType);
   }, [selectedType]);
 
-  const handleSelect = (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT') => {
+  const handleSelect = (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER') => {
     onSelectType(type);
   };
 
@@ -81,7 +81,7 @@ const ChooseType: React.FC<ChooseTypeProps> = ({ selectedType, onValidChange, on
       icon: Binary,
     },
     {
-      id: 'SHORT' as const,
+      id: 'SHORT_ANSWER' as const,
       title: '단답형',
       content: '짧은 답변 직접 작성',
       icon: PenLine,

--- a/src/features/create/innerPages/ChooseType.tsx
+++ b/src/features/create/innerPages/ChooseType.tsx
@@ -59,7 +59,6 @@ const InfoContent = styled.p<{ selected: boolean }>`
 `;
 
 const ChooseType: React.FC<ChooseTypeProps> = ({ selectedType, onValidChange, onSelectType }) => {
-  // ✅ onValidChange를 의존성 배열에 추가합니다.
   useEffect(() => {
     onValidChange(!!selectedType);
   }, [selectedType, onValidChange]);

--- a/src/features/create/innerPages/ChooseType.tsx
+++ b/src/features/create/innerPages/ChooseType.tsx
@@ -3,12 +3,13 @@ import Title from '@/features/create/components/Title';
 import StyledSubTitle from '@/features/create/components/Subtitle';
 import styled from '@emotion/styled';
 import Spacer from '@/shared/components/Spacer';
-import { ListChecks, Binary, PenLine } from 'lucide-react';
+import type { QuestionType } from '@/features/create/constants/questionTypeConstants';
+import { QUESTION_TYPE_DATA } from '@/features/create/constants/questionTypeConstants';
 
 interface ChooseTypeProps {
-  selectedType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER' | null;
+  selectedType: QuestionType | null;
   onValidChange: (isValid: boolean) => void;
-  onSelectType: (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER') => void;
+  onSelectType: (type: QuestionType) => void;
 }
 
 const InfoContainer = styled.div`
@@ -63,30 +64,9 @@ const ChooseType: React.FC<ChooseTypeProps> = ({ selectedType, onValidChange, on
     onValidChange(!!selectedType);
   }, [selectedType, onValidChange]);
 
-  const handleSelect = (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER') => {
+  const handleSelect = (type: QuestionType) => {
     onSelectType(type);
   };
-
-  const infoData = [
-    {
-      id: 'MULTIPLE_CHOICE' as const,
-      title: '객관식',
-      content: '4개 선택지 중 정답 선택',
-      icon: ListChecks,
-    },
-    {
-      id: 'TRUE_FALSE' as const,
-      title: '참/거짓',
-      content: '참 또는 거짓 중 선택',
-      icon: Binary,
-    },
-    {
-      id: 'SHORT_ANSWER' as const,
-      title: '단답형',
-      content: '짧은 답변 직접 작성',
-      icon: PenLine,
-    },
-  ];
 
   return (
     <>
@@ -94,7 +74,7 @@ const ChooseType: React.FC<ChooseTypeProps> = ({ selectedType, onValidChange, on
       <StyledSubTitle>어떤 형태의 문제를 생성할까요</StyledSubTitle>
       <Spacer height="12px" />
       <InfoContainer>
-        {infoData.map(({ id, title, content, icon: IconComponent }) => {
+        {QUESTION_TYPE_DATA.map(({ id, title, description, icon: IconComponent }) => {
           const selected = selectedType === id;
           const iconColor = selected ? 'white' : 'currentColor';
 
@@ -111,7 +91,7 @@ const ChooseType: React.FC<ChooseTypeProps> = ({ selectedType, onValidChange, on
                 <IconComponent size={20} color={iconColor} />
                 <InfoTitle selected={selected}>{title}</InfoTitle>
               </TitleContainer>
-              <InfoContent selected={selected}>{content}</InfoContent>
+              <InfoContent selected={selected}>{description}</InfoContent>
             </RadioCard>
           );
         })}

--- a/src/features/create/innerPages/ChooseType.tsx
+++ b/src/features/create/innerPages/ChooseType.tsx
@@ -59,9 +59,10 @@ const InfoContent = styled.p<{ selected: boolean }>`
 `;
 
 const ChooseType: React.FC<ChooseTypeProps> = ({ selectedType, onValidChange, onSelectType }) => {
+  // ✅ onValidChange를 의존성 배열에 추가합니다.
   useEffect(() => {
     onValidChange(!!selectedType);
-  }, [selectedType]);
+  }, [selectedType, onValidChange]);
 
   const handleSelect = (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER') => {
     onSelectType(type);

--- a/src/features/create/innerPages/CreateRequest.tsx
+++ b/src/features/create/innerPages/CreateRequest.tsx
@@ -12,7 +12,7 @@ interface CreateRequestProps {
   questionSetId: number;
   setQuestionSetId: (id: number) => void;
   setQuestionSetReady: (isReady: boolean) => void;
-  questionType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT' | null;
+  questionType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER' | null;
 }
 
 const Container = styled.div`
@@ -141,7 +141,7 @@ const CreateRequest: React.FC<CreateRequestProps> = ({
         return '객관식';
       case 'TRUE_FALSE':
         return '참/거짓';
-      case 'SHORT':
+      case 'SHORT_ANSWER':
         return '단답형';
       default:
         return '알 수 없음';

--- a/src/features/create/innerPages/CreateRequest.tsx
+++ b/src/features/create/innerPages/CreateRequest.tsx
@@ -4,6 +4,8 @@ import Spacer from '@/shared/components/Spacer';
 import { useEffect, useState } from 'react';
 import Complete from '@/features/create/components/Complete';
 import api from '@/shared/api/axiosClient';
+import type { QuestionType } from '@/features/create/constants/questionTypeConstants';
+import { QUESTION_TYPE_MAP } from '@/features/create/constants/questionTypeConstants';
 
 interface CreateRequestProps {
   selectedFile: { id: string; name: string | null } | null;
@@ -12,7 +14,7 @@ interface CreateRequestProps {
   questionSetId: number;
   setQuestionSetId: (id: number) => void;
   setQuestionSetReady: (isReady: boolean) => void;
-  questionType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER' | null;
+  questionType: QuestionType | null;
 }
 
 const Container = styled.div`
@@ -135,19 +137,6 @@ const CreateRequest: React.FC<CreateRequestProps> = ({
     );
   }
 
-  const renderQuestionTypeText = () => {
-    switch (questionType) {
-      case 'MULTIPLE_CHOICE':
-        return '객관식';
-      case 'TRUE_FALSE':
-        return '참/거짓';
-      case 'SHORT_ANSWER':
-        return '단답형';
-      default:
-        return '알 수 없음';
-    }
-  };
-
   return (
     <Container>
       <Spinner />
@@ -155,8 +144,10 @@ const CreateRequest: React.FC<CreateRequestProps> = ({
       <NoticeTitle>AI가 문제를 생성하고 있습니다.</NoticeTitle>
       <NoticeContent>
         선택하신 PDF에서 <NoticeContentHighlight>10개</NoticeContentHighlight>의{' '}
-        <NoticeContentHighlight>{renderQuestionTypeText()}</NoticeContentHighlight> 문제를 생성하고
-        있어요
+        <NoticeContentHighlight>
+          {questionType ? QUESTION_TYPE_MAP.get(questionType)?.title : '알 수 없음'}
+        </NoticeContentHighlight>{' '}
+        문제를 생성하고 있어요
       </NoticeContent>
     </Container>
   );

--- a/src/features/create/innerPages/CreateSummary.tsx
+++ b/src/features/create/innerPages/CreateSummary.tsx
@@ -7,7 +7,7 @@ import Spacer from '@/shared/components/Spacer';
 interface CreateSummaryProps {
   onValidChange: (isValid: boolean) => void;
   selectedFile: { id: string; name: string | null } | null;
-  questionType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT' | null;
+  questionType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER' | null;
 }
 
 const InfoContainer = styled.div`
@@ -58,9 +58,9 @@ const CreateSummary: React.FC<CreateSummaryProps> = ({
   }, []);
 
   const questionTypeDetails = {
-    MULTIPLE_CHOICE: { content: '객관식', description: '4지 선다형' },
+    MULTIPLE_CHOICE: { content: '객관식', description: '4개 선택지 중 정답 선택' },
     TRUE_FALSE: { content: '참/거짓', description: '참 또는 거짓 중 선택' },
-    SHORT: { content: '단답형', description: '짧은 답변 직접 작성' },
+    SHORT_ANSWER: { content: '단답형', description: '짧은 답변 직접 작성' },
   };
 
   const selectedTypeDetails = questionType

--- a/src/features/create/innerPages/CreateSummary.tsx
+++ b/src/features/create/innerPages/CreateSummary.tsx
@@ -3,11 +3,13 @@ import Title from '@/features/create/components/Title';
 import StyledSubTitle from '@/features/create/components/Subtitle';
 import styled from '@emotion/styled';
 import Spacer from '@/shared/components/Spacer';
+import type { QuestionType } from '@/features/create/constants/questionTypeConstants';
+import { QUESTION_TYPE_MAP } from '@/features/create/constants/questionTypeConstants';
 
 interface CreateSummaryProps {
   onValidChange: (isValid: boolean) => void;
   selectedFile: { id: string; name: string | null } | null;
-  questionType: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER' | null;
+  questionType: QuestionType | null;
 }
 
 const InfoContainer = styled.div`
@@ -57,15 +59,9 @@ const CreateSummary: React.FC<CreateSummaryProps> = ({
     onValidChange(true);
   }, [onValidChange]);
 
-  const questionTypeDetails = {
-    MULTIPLE_CHOICE: { content: '객관식', description: '4개 선택지 중 정답 선택' },
-    TRUE_FALSE: { content: '참/거짓', description: '참 또는 거짓 중 선택' },
-    SHORT_ANSWER: { content: '단답형', description: '짧은 답변 직접 작성' },
-  };
-
   const selectedTypeDetails = questionType
-    ? questionTypeDetails[questionType]
-    : { content: '미선택', description: '문제 유형을 선택해주세요.' };
+    ? QUESTION_TYPE_MAP.get(questionType)
+    : { title: '미선택', description: '문제 유형을 선택해주세요.' };
 
   const infoData = [
     {
@@ -76,8 +72,8 @@ const CreateSummary: React.FC<CreateSummaryProps> = ({
     { title: '문제 개수', content: '10문제', description: 'PDF 내용으로만' },
     {
       title: '문제 유형',
-      content: selectedTypeDetails.content,
-      description: selectedTypeDetails.description,
+      content: selectedTypeDetails?.title ?? '미선택',
+      description: selectedTypeDetails?.description ?? '문제 유형을 선택해주세요.',
     },
   ];
 

--- a/src/features/create/innerPages/CreateSummary.tsx
+++ b/src/features/create/innerPages/CreateSummary.tsx
@@ -53,7 +53,6 @@ const CreateSummary: React.FC<CreateSummaryProps> = ({
   selectedFile,
   questionType,
 }) => {
-  // ✅ onValidChange를 의존성 배열에 추가합니다.
   useEffect(() => {
     onValidChange(true);
   }, [onValidChange]);

--- a/src/features/create/innerPages/CreateSummary.tsx
+++ b/src/features/create/innerPages/CreateSummary.tsx
@@ -53,9 +53,10 @@ const CreateSummary: React.FC<CreateSummaryProps> = ({
   selectedFile,
   questionType,
 }) => {
+  // ✅ onValidChange를 의존성 배열에 추가합니다.
   useEffect(() => {
     onValidChange(true);
-  }, []);
+  }, [onValidChange]);
 
   const questionTypeDetails = {
     MULTIPLE_CHOICE: { content: '객관식', description: '4개 선택지 중 정답 선택' },

--- a/src/features/create/innerPages/SelectPdf.tsx
+++ b/src/features/create/innerPages/SelectPdf.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import PdfFileList from '@/features/create/components/PdfFileList';
 import type { FileData } from '@/features/create/types/types';
@@ -36,30 +36,40 @@ const SelectPdf = ({ selectedFileId, onValidChange, onSelectFile }: Step1Props) 
     },
   });
 
+  const handleSelectFile = useCallback(
+    (fileId: string | null) => {
+      onValidChange(!!fileId);
+
+      if (fileId) {
+        const selected = fileList.find((file) => file.id === fileId);
+        if (selected) {
+          onSelectFile({ id: selected.id, name: selected.name });
+        }
+      } else {
+        onSelectFile(null);
+      }
+    },
+    [fileList, onSelectFile, onValidChange],
+  );
+
+  const handleUpload = useCallback(
+    (file: File) => {
+      onSelectFile(null);
+      onValidChange(false);
+      upload(file);
+    },
+    [onSelectFile, onValidChange, upload],
+  );
+
   useEffect(() => {
     if (isError) {
       alert('PDF 목록을 불러오는 데 실패했습니다.');
     }
   }, [isError]);
 
-  const handleSelectFile = (fileId: string | null) => {
-    onValidChange(!!fileId);
-
-    if (fileId) {
-      const selected = fileList.find((file) => file.id === fileId);
-      if (selected) {
-        onSelectFile({ id: selected.id, name: selected.name });
-      }
-    } else {
-      onSelectFile(null);
-    }
-  };
-
-  const handleUpload = (file: File) => {
-    onSelectFile(null);
-    onValidChange(false);
-    upload(file);
-  };
+  useEffect(() => {
+    onValidChange(!!selectedFileId);
+  }, [selectedFileId, onValidChange]);
 
   return (
     <>

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -36,7 +36,7 @@ const Create = () => {
   const [selectedFile, setSelectedFile] = useState<{ id: string; name: string } | null>(null);
 
   const [questionType, setQuestionType] = useState<
-    'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT' | null
+    'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER' | null
   >(null);
 
   const { questionSetId, questionSetReady, setQuestionSetId, setQuestionSetReady } =
@@ -115,7 +115,7 @@ const Create = () => {
     setQuestionSetReady(false);
   };
 
-  const progress = ((currentStep - 1) / (stepLabels.length - 1)) * 100;
+  const progress = (currentStep / stepLabels.length) * 100;
 
   return (
     <PageLayout>

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import CommonProgress from '@/shared/components/ProgressBar/CommonProgress';
 import PageLayout from '@/shared/components/Layout/PageLayout';
 import SelectPdf from '@/features/create/innerPages/SelectPdf';
@@ -49,6 +49,30 @@ const Create = () => {
     4: false,
   });
 
+  // ✅ useCallback으로 함수들을 감싸서 불필요한 재생성을 방지합니다.
+  const handleStep1ValidChange = useCallback((isValid: boolean) => {
+    setStepValidity((prev) => ({ ...prev, 1: isValid }));
+  }, []);
+
+  const handleStep2ValidChange = useCallback((isValid: boolean) => {
+    setStepValidity((prev) => ({ ...prev, 2: isValid }));
+  }, []);
+
+  const handleStep3ValidChange = useCallback((isValid: boolean) => {
+    setStepValidity((prev) => ({ ...prev, 3: isValid }));
+  }, []);
+
+  const handleSelectFile = useCallback((fileInfo: { id: string; name: string } | null) => {
+    setSelectedFile(fileInfo);
+  }, []);
+
+  const handleSelectType = useCallback(
+    (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER') => {
+      setQuestionType(type);
+    },
+    [],
+  );
+
   const isNextDisabled = !stepValidity[currentStep];
 
   const renderStepComponent = () => {
@@ -57,16 +81,16 @@ const Create = () => {
         return (
           <SelectPdf
             selectedFileId={selectedFile?.id ?? null}
-            onValidChange={(isValid) => setStepValidity((prev) => ({ ...prev, 1: isValid }))}
-            onSelectFile={(fileInfo) => setSelectedFile(fileInfo)}
+            onValidChange={handleStep1ValidChange}
+            onSelectFile={handleSelectFile}
           />
         );
       case 2:
         return (
           <ChooseType
             selectedType={questionType}
-            onValidChange={(isValid) => setStepValidity((prev) => ({ ...prev, 2: isValid }))}
-            onSelectType={(type) => setQuestionType(type)}
+            onValidChange={handleStep2ValidChange}
+            onSelectType={handleSelectType}
           />
         );
       case 3:
@@ -74,7 +98,7 @@ const Create = () => {
           <CreateSummary
             selectedFile={selectedFile}
             questionType={questionType}
-            onValidChange={(isValid) => setStepValidity((prev) => ({ ...prev, 3: isValid }))}
+            onValidChange={handleStep3ValidChange}
           />
         );
       case 4:

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -9,6 +9,7 @@ import CreateRequest from '@/features/create/innerPages/CreateRequest';
 import Spacer from '@/shared/components/Spacer';
 import { useOutletContext } from 'react-router-dom';
 import ChooseType from '@/features/create/innerPages/ChooseType';
+import type { QuestionType } from '@/features/create/constants/questionTypeConstants';
 
 const CreateWrapper = styled.div`
   display: flex;
@@ -34,10 +35,7 @@ const Create = () => {
   const stepLabels = ['PDF 선택', '문제 유형', '생성 요약', '생성하기'];
   const [currentStep, setCurrentStep] = useState(1);
   const [selectedFile, setSelectedFile] = useState<{ id: string; name: string } | null>(null);
-
-  const [questionType, setQuestionType] = useState<
-    'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER' | null
-  >(null);
+  const [questionType, setQuestionType] = useState<QuestionType | null>(null);
 
   const { questionSetId, questionSetReady, setQuestionSetId, setQuestionSetReady } =
     useOutletContext<CreateProps>();
@@ -49,7 +47,7 @@ const Create = () => {
     4: false,
   });
 
-  // useCallback을 사용해 불필요한 재생성 방지(의존성 배열 수칙 위배 경고에 따른 대처)
+  // 의존성 규칙에 위배사항 발생으로 useCallback으로 안정화 처리
   const handleStep1ValidChange = useCallback((isValid: boolean) => {
     setStepValidity((prev) => ({ ...prev, 1: isValid }));
   }, []);
@@ -66,12 +64,9 @@ const Create = () => {
     setSelectedFile(fileInfo);
   }, []);
 
-  const handleSelectType = useCallback(
-    (type: 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER') => {
-      setQuestionType(type);
-    },
-    [],
-  );
+  const handleSelectType = useCallback((type: QuestionType) => {
+    setQuestionType(type);
+  }, []);
 
   const isNextDisabled = !stepValidity[currentStep];
 

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -49,7 +49,7 @@ const Create = () => {
     4: false,
   });
 
-  // ✅ useCallback으로 함수들을 감싸서 불필요한 재생성을 방지합니다.
+  // useCallback을 사용해 불필요한 재생성 방지(의존성 배열 수칙 위배 경고에 따른 대처)
   const handleStep1ValidChange = useCallback((isValid: boolean) => {
     setStepValidity((prev) => ({ ...prev, 1: isValid }));
   }, []);


### PR DESCRIPTION
## PR 설명

- 문제 생성 페이지의 버그와 코드 리팩토링을 수행한 PR입니다.

## 작업 상세 내용

- 네비게이션 바 쏠림 현상 개선
- 프로그래스바 버그 수정(진행 현황 불일치)
- 타입 유형 상수 분리(리팩토링)

## 기타사항 / 참고사항

- 지금 문제 재생성 요청시 무한 SSE 알림이 뜨는 버그가 발생했습니다.
- 저희가 이전에 setQuestionSetReady를 false로 줌으로써 이 문제를 해결했었는데, 만약 문제 생성 페이지에서 SSE를 연결한다고 하면 이를 toast가 떴을 때 close 해주고 싶습니다.
- 그런데 이럴 경우 문제가 생성 중일 경우에는 기존 SSE를 유지하거나 하는 식의 분리 로직도 필요할 것입니다.
- 참고 후 수정 부탁드립니다.
