### PR TITLE
FTSK-67: 문제풀이 선지 유지 및 푼 문항 문제네비게이션에 표시되도록함

### DIFF
--- a/src/features/solve/components/QuestionArea.tsx
+++ b/src/features/solve/components/QuestionArea.tsx
@@ -141,17 +141,17 @@ function QuestionArea({
 
   useEffect(() => {
     const currentQuestion = questions.questions.at(currentQuestionIndex - 1);
-  if (!currentQuestion) return;
+    if (!currentQuestion) return;
 
-  // solvedCheck 배열에서 현재 문제의 기록 찾기
-  const solved = solvedCheck.find((v) => v.questionId === currentQuestion.id);
-  if (solved) {
-    // options 배열에서 선택된 보기의 인덱스 찾아서 복원
-    const idx = currentQuestion.options.findIndex((opt) => opt === solved.memberAnswer);
-    setSelectedOption(idx);
-  } else {
-    setSelectedOption(null);
-  }
+    // solvedCheck 배열에서 현재 문제의 기록 찾기
+    const solved = solvedCheck.find((v) => v.questionId === currentQuestion.id);
+    if (solved) {
+      // options 배열에서 선택된 보기의 인덱스 찾아서 복원
+      const idx = currentQuestion.options.findIndex((opt) => opt === solved.memberAnswer);
+      setSelectedOption(idx);
+    } else {
+      setSelectedOption(null);
+    }
   }, [currentQuestionIndex, solvedCheck, questions]);
 
   return (

--- a/src/features/solve/components/QuestionArea.tsx
+++ b/src/features/solve/components/QuestionArea.tsx
@@ -140,8 +140,19 @@ function QuestionArea({
   };
 
   useEffect(() => {
+    const currentQuestion = questions.questions.at(currentQuestionIndex - 1);
+  if (!currentQuestion) return;
+
+  // solvedCheck 배열에서 현재 문제의 기록 찾기
+  const solved = solvedCheck.find((v) => v.questionId === currentQuestion.id);
+  if (solved) {
+    // options 배열에서 선택된 보기의 인덱스 찾아서 복원
+    const idx = currentQuestion.options.findIndex((opt) => opt === solved.memberAnswer);
+    setSelectedOption(idx);
+  } else {
     setSelectedOption(null);
-  }, [currentQuestionIndex]);
+  }
+  }, [currentQuestionIndex, solvedCheck, questions]);
 
   return (
     <QuestionAreaWrapper>

--- a/src/features/solve/components/QuestionNavigator.tsx
+++ b/src/features/solve/components/QuestionNavigator.tsx
@@ -57,9 +57,9 @@ function QuestionNavigator({
   solvedCheck,
   setCurrentQuestionIndex,
   questionLength,
-  questions
+  questions,
 }: QuestionNavigatorProps) {
-  console.log()
+  console.log();
   return (
     <QuestionNavigatorWrapper>
       <QuestionNavigatorTitle>문제 바로가기</QuestionNavigatorTitle>

--- a/src/features/solve/components/QuestionNavigator.tsx
+++ b/src/features/solve/components/QuestionNavigator.tsx
@@ -59,7 +59,6 @@ function QuestionNavigator({
   questionLength,
   questions,
 }: QuestionNavigatorProps) {
-  
   return (
     <QuestionNavigatorWrapper>
       <QuestionNavigatorTitle>문제 바로가기</QuestionNavigatorTitle>

--- a/src/features/solve/components/QuestionNavigator.tsx
+++ b/src/features/solve/components/QuestionNavigator.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import type { MarkingRequest } from '../types/MarkingRequest';
+import type { QuestionSet } from '@/features/solve/types/question';
 
 const QuestionNavigatorWrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.gray.gray0};
@@ -49,13 +50,16 @@ type QuestionNavigatorProps = {
   solvedCheck: MarkingRequest[];
   setCurrentQuestionIndex: React.Dispatch<React.SetStateAction<number>>;
   questionLength: number;
+  questions: QuestionSet;
 };
 function QuestionNavigator({
   currentQuestionIndex,
   solvedCheck,
   setCurrentQuestionIndex,
   questionLength,
+  questions
 }: QuestionNavigatorProps) {
+  console.log()
   return (
     <QuestionNavigatorWrapper>
       <QuestionNavigatorTitle>문제 바로가기</QuestionNavigatorTitle>
@@ -64,7 +68,7 @@ function QuestionNavigator({
           <QuestionNumberItem
             key={i + 1}
             active={i + 1 === currentQuestionIndex}
-            solved={!!solvedCheck.find((v) => v.questionId == i + 1)}
+            solved={!!solvedCheck.find((v) => v.questionId == questions.questions[i].id)} // TODO: 이부분 수정해야할듯
             onClick={() => setCurrentQuestionIndex(i + 1)}
           >
             {i + 1}
@@ -74,5 +78,4 @@ function QuestionNavigator({
     </QuestionNavigatorWrapper>
   );
 }
-
 export default QuestionNavigator;

--- a/src/features/solve/components/QuestionNavigator.tsx
+++ b/src/features/solve/components/QuestionNavigator.tsx
@@ -67,7 +67,7 @@ function QuestionNavigator({
           <QuestionNumberItem
             key={i + 1}
             active={i + 1 === currentQuestionIndex}
-            solved={!!solvedCheck.find((v) => v.questionId == questions.questions[i].id)} // TODO: 이부분 수정해야할듯
+            solved={!!solvedCheck.find((v) => v.questionId === questions.questions[i].id)}
             onClick={() => setCurrentQuestionIndex(i + 1)}
           >
             {i + 1}

--- a/src/features/solve/components/QuestionNavigator.tsx
+++ b/src/features/solve/components/QuestionNavigator.tsx
@@ -59,7 +59,7 @@ function QuestionNavigator({
   questionLength,
   questions,
 }: QuestionNavigatorProps) {
-  console.log();
+  
   return (
     <QuestionNavigatorWrapper>
       <QuestionNavigatorTitle>문제 바로가기</QuestionNavigatorTitle>

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -44,15 +44,16 @@ const RightSidebar = styled.div`
 `;
 
 function Solve() {
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState<number>(1);
-  const [solvedCheck, setSolvedCheck] = useState<MarkingRequest[]>([]);
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState<number>(1); // 현재 풀고있는 문항 위치
+  const [solvedCheck, setSolvedCheck] = useState<MarkingRequest[]>([]); // 문항에 대한 배열이고 각 문항의 필드는 문항 id, 선택한 답, 선택한 답에 대한 타입으로 구성됨
   const [isAllSolved, setIsAllSolved] = useState<boolean>(false); // 전체 문제가 다 풀렸는지 감지는 solvedCheck state가 다찼는지르 확인 할 수 있음 제거헤도 될듯
   const [selectedMode, setSelectedMode] = useState<string>('시험'); // 문제 풀이 모드 선택 얜 신경쓰지마 아직 무시해
-  const { questionSetId } = useParams<{ questionSetId: string }>();
+  const { questionSetId } = useParams<{ questionSetId: string }>(); // 문제집 id를 받아와서 문제집을 출력함
   const [searchParams] = useSearchParams();
 
   const isReviewing = searchParams.get('isReviewing') === 'true';
 
+  console.log("풀고있는 문제 state",solvedCheck);
   // 1. 서버로부터 문제조회를 하는 부분 questionSetId로 문제집 조회
   const { isPending, error, data } = useQuery({
     queryKey: ['questionSet', questionSetId, isReviewing],
@@ -109,6 +110,7 @@ function Solve() {
               solvedCheck={solvedCheck}
               setCurrentQuestionIndex={setCurrentQuestionIndex}
               questionLength={data.questions.length}
+              questions={data}
             />
             <SolveContentWrapper>
               <QuestionArea

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -53,7 +53,7 @@ function Solve() {
 
   const isReviewing = searchParams.get('isReviewing') === 'true';
 
-  console.log("풀고있는 문제 state",solvedCheck);
+  console.log('풀고있는 문제 state', solvedCheck);
   // 1. 서버로부터 문제조회를 하는 부분 questionSetId로 문제집 조회
   const { isPending, error, data } = useQuery({
     queryKey: ['questionSet', questionSetId, isReviewing],


### PR DESCRIPTION
## PR 설명

- 제풀이 선지 유지 및 푼 문항 문제네비게이션에 표시되도록함

## 작업 상세 내용

- 제풀이 선지 유지 및 푼 문항 문제네비게이션에 표시되도록함
## 기타사항 / 참고사항

- 크아아아악 빨리 리팩토링먼저 해야겠다 코드보는데 토나올것같아요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Previously selected answers are preserved when navigating between questions instead of being cleared.
  * Solved indicators in the navigator now track actual questions, so completion status remains correct when questions are reordered or non-sequential.
  * Selections are restored when question data changes, reducing accidental loss of progress.

* **Chores**
  * Added brief inline comments and a debug log to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->