### PR TITLE
FTSK-79: 레이아웃 안정화 작업, 일부 UI 개선

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import CalendarHeatmapCompo from '@/features/dashboard/CalendarHeatmapCompo';
 const DashboardWrapper = styled.div`
   width: 100%;
   padding: ${({ theme }) => theme.spacing.spacing5};
-  height: calc(100dvh - 76px);
+  height: 100%;
   overflow-y: auto;
   box-sizing: border-box;
   justify-content: flex-start;

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -21,7 +21,7 @@ const Container = styled.div`
   align-items: center;
   padding: 20px;
   background-color: ${({ theme }) => theme.colors.background.background};
-  height: calc(100dvh - 76px);
+  height: 100%;
   overflow-y: auto;
   box-sizing: border-box;
   justify-content: flex-start;

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -416,9 +416,9 @@ const Library = () => {
                   <ListCell>
                     {new Intl.DateTimeFormat('sv-SE').format(new Date(item.createdAt))}
                   </ListCell>
-                  <ListCell>{TYPE_MAP[item.questionType] ?? '알 수 없음'}</ListCell>
+                  <ListCell>{TYPE_MAP[item.questionType] ?? '생성 실패'}</ListCell>
                   <StatusCell status={item.status}>
-                    {STATUS_MAP[item.status] ?? '알 수 없음'}
+                    {STATUS_MAP[item.status] ?? '생성 실패'}
                   </StatusCell>
                   <ListCell>
                     {item.status === 'COMPLETE' && (

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -5,6 +5,7 @@ import api from '@/shared/api/axiosClient';
 import { useQuery } from '@tanstack/react-query';
 import type { WrongNoteSetResponse } from '@/features/wrong/types/wrongNote';
 import { useState, useEffect } from 'react';
+import Spinner from '@/shared/components/Spinner';
 
 const WrongWrapper = styled.div`
   display: flex;
@@ -135,7 +136,7 @@ function Wrong() {
   );
 
   // 로딩
-  if (isPending) return <h1>Loading...</h1>;
+  if (isPending) return <Spinner/>;
   // 에러
   if (error) return <h1>Error</h1>;
 

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -12,7 +12,7 @@ const WrongWrapper = styled.div`
   align-items: center;
   padding: 20px;
   background-color: ${({ theme }) => theme.colors.background.background};
-  height: calc(100dvh - 76px);
+  height: 100%;
   overflow-y: auto;
   box-sizing: border-box;
   justify-content: flex-start;

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -136,7 +136,7 @@ function Wrong() {
   );
 
   // 로딩
-  if (isPending) return <Spinner/>;
+  if (isPending) return <Spinner />;
   // 에러
   if (error) return <h1>Error</h1>;
 

--- a/src/pages/layout/AppLayout.tsx
+++ b/src/pages/layout/AppLayout.tsx
@@ -12,6 +12,7 @@ const AppLayoutWrapper = styled.div`
   width: 100%;
   height: 100dvh;
   min-height: ${MIN_HEIGHT};
+  min-width: 1050px;
   display: flex;
   overflow: hidden;
 `;
@@ -33,6 +34,7 @@ const Main = styled.div`
   min-width: 800px;
   background-color: ${({ theme }) => theme.colors.gray.gray2};
   flex: 1;
+  height: calc(100% - 76px);
 `;
 
 function AppLayout() {

--- a/src/shared/components/SideBar/SideBar.tsx
+++ b/src/shared/components/SideBar/SideBar.tsx
@@ -155,12 +155,16 @@ const SideBarUserInfoTextWrapper = styled.div`
   display: flex;
   flex-direction: column;
   margin-left: ${({ theme }) => theme.spacing.spacing2};
+  width: 145px;
 `;
 
 const SideBarUserInfoName = styled.p`
   font-size: ${({ theme }) => theme.typography.label2Bold.fontSize};
   font-weight: ${({ theme }) => theme.typography.label2Bold.fontWeight};
   line-height: ${({ theme }) => theme.typography.label2Bold.lineHeight};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `;
 
 const SideBarUserInfoEmail = styled.p`
@@ -168,6 +172,10 @@ const SideBarUserInfoEmail = styled.p`
   font-weight: ${({ theme }) => theme.typography.label1Regular.fontWeight};
   line-height: ${({ theme }) => theme.typography.label1Regular.lineHeight};
   color: ${({ theme }) => theme.colors.gray.gray7};
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `;
 
 const DropdownWrapper = styled.div`

--- a/src/shared/config/constants.ts
+++ b/src/shared/config/constants.ts
@@ -12,4 +12,4 @@ export type Menu = (typeof MENUS)[keyof typeof MENUS];
 
 // 레이아웃 상수
 export const MIN_WIDTH = '1260px';
-export const MIN_HEIGHT = '640px';
+export const MIN_HEIGHT = '600px';


### PR DESCRIPTION
## PR 설명

- 레이아웃 안정화 작업, 일부 UI 개선 PR 입니다.

## 작업 상세 내용

- 화면 축소 시 무너지는 레이아웃 안정화 작업
- 사이드바 계정정보 이름/이메일 초과 시 ... 처리
- wrong 페이지 전역 스피너 적용

## 기타사항 / 참고사항

- 성현씨가 작업했던 wrong 페이지의 loading 상태 반환을 전역 스피너로 수정하였습니다.
- 오답노트 페이지에서 화면 축소 시 글씨가 초과될 경우 ...으로 바꾸는 것을 적용하고자 하였으나, 현 방식이 grid 방식이기에 적용 시 대대적인 수정이 필요할 것 같아서 유지했습니다. 이 부분 추후 상의하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved page layout height calculations across multiple pages.
  * Enhanced sidebar display with text truncation and ellipsis for long names and emails.
  * Adjusted layout sizing constraints and minimum dimensions.

* **New Features**
  * Updated loading indicator to display a Spinner component.

* **Bug Fixes**
  * Updated fallback labels for failed question generation and status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->