### PR TITLE
FTSK-85: 나의 문제집 폴더 추가

### DIFF
--- a/src/features/library/types/questionSetResponse.ts
+++ b/src/features/library/types/questionSetResponse.ts
@@ -11,4 +11,6 @@ export interface MyQuestionSetsResponse {
   difficultyType: DifficultyType;
   questionType: QuestionType;
   createdAt: string;
+  commonFolderId: number;
+  commonFolderName: string;
 }

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -286,6 +286,44 @@ const EditIconButton = styled.button`
   }
 `;
 
+const FolderSelectWrapper = styled.div`
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const FolderSelectLabel = styled.span`
+  font-size: 14px;
+  color: #333;
+  white-space: nowrap;
+`;
+
+const FolderSelect = styled.select`
+  flex: 1;
+  padding: 6px 8px;
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-radius: ${({ theme }) => theme.radius.radius2};
+  font-size: 14px;
+  background-color: ${({ theme }) => theme.colors.background.foreground};
+  color: ${({ theme }) => theme.colors.text.default};
+  cursor: pointer;
+  outline: none;
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.semantic.primary};
+  }
+
+  &:focus {
+    border-color: ${({ theme }) => theme.colors.semantic.primary};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+`;
+
 const TYPE_MAP: Record<QuestionType, string> = {
   MULTIPLE_CHOICE: '객관식',
   SHORT_ANSWER: '단답형',
@@ -627,6 +665,18 @@ const Library = () => {
     setIsVisibleMenu(false);
   }, [selectedCell, handleSolveClick]);
 
+  const handleMenuMoveToFolder = useCallback(
+    (folderId: number) => {
+      if (!selectedCell) return;
+      moveFolderMutation.mutate({
+        questionSetId: selectedCell.questionSetId,
+        folderId: folderId,
+      });
+      setIsVisibleMenu(false);
+    },
+    [selectedCell, moveFolderMutation],
+  );
+
   const handleFolderMenuRename = useCallback(() => {
     if (!selectedFolder) return;
     setEditingFolderId(selectedFolder.id);
@@ -694,6 +744,31 @@ const Library = () => {
           disabled={selectedCell?.status !== 'COMPLETE'}
         />
         <RightClickMenuDivider />
+        {folders && folders.length > 0 && (
+          <>
+            <FolderSelectWrapper>
+              <FolderSelectLabel>📁 폴더 이동</FolderSelectLabel>
+              <FolderSelect
+                disabled={selectedCell?.status !== 'COMPLETE'}
+                defaultValue={selectedFolderId ?? ''}
+                onChange={(e) => {
+                  const targetFolderId = Number(e.target.value);
+                  if (targetFolderId !== selectedFolderId) {
+                    handleMenuMoveToFolder(targetFolderId);
+                  }
+                }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {folders.map((folder) => (
+                  <option key={folder.id} value={folder.id}>
+                    {folder.name}
+                  </option>
+                ))}
+              </FolderSelect>
+            </FolderSelectWrapper>
+            <RightClickMenuDivider />
+          </>
+        )}
         <RightClickMenuItem
           icon="📝"
           title="문제집 풀기"

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -17,6 +17,15 @@ import RightClickMenu from '@/features/library/components/RightClickMenu/RightCl
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import RightClickMenuDivider from '@/features/library/components/RightClickMenu/RightClickMenuDivider';
 
+interface Folder {
+  id: number;
+  name: string;
+  type: 'QUESTION_SET';
+  sortOrder: number;
+}
+
+const QUESTION_SET_TYPE = 'QUESTION_SET';
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -50,6 +59,106 @@ const FileListSearchInput = styled.input`
   }
 `;
 
+const FolderContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+`;
+
+const FolderTag = styled.div<{
+  isDragOver?: boolean;
+  folderColor: string;
+  folderHoverColor: string;
+}>`
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: ${({ theme }) => theme.radius.radius2};
+  background-color: ${({ isDragOver, folderColor, folderHoverColor }) =>
+    isDragOver ? folderHoverColor : folderColor};
+  border: 1px solid
+    ${({ isDragOver, folderHoverColor }) => (isDragOver ? folderHoverColor : 'transparent')};
+  font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
+  color: white;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  user-select: none;
+  font-weight: 500;
+
+  &:hover {
+    background-color: ${({ folderHoverColor }) => folderHoverColor};
+    border-color: ${({ folderHoverColor }) => folderHoverColor};
+    color: white;
+  }
+`;
+
+const AddFolderButton = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: ${({ theme }) => theme.radius.radius2};
+  background-color: ${({ theme }) => theme.colors.background.foreground};
+  border: 1px dashed ${({ theme }) => theme.colors.border.border1};
+  font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
+  color: ${({ theme }) => theme.colors.text.default};
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  user-select: none;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.semantic.primary};
+    border-color: ${({ theme }) => theme.colors.semantic.primary};
+    border-style: solid;
+    color: white;
+  }
+`;
+
+const FolderInputContainer = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: ${({ theme }) => theme.radius.radius2};
+  background-color: ${({ theme }) => theme.colors.background.foreground};
+  border: 1px solid ${({ theme }) => theme.colors.semantic.primary};
+`;
+
+const FolderInput = styled.input`
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
+  color: ${({ theme }) => theme.colors.text.default};
+  width: 120px;
+  padding: 0;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.subtitle};
+  }
+`;
+
+const FolderActionButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  transition: transform 0.1s;
+
+  &:hover {
+    transform: scale(1.2);
+  }
+
+  &:active {
+    transform: scale(0.9);
+  }
+`;
+
 const ListBox = styled.div`
   display: flex;
   flex-direction: column;
@@ -59,7 +168,7 @@ const ListBox = styled.div`
   overflow: hidden;
 `;
 
-const ListRow = styled.div`
+const ListRow = styled.div<{ isDragging?: boolean }>`
   display: grid;
   grid-template-columns: 3fr 1fr 1.2fr 1fr 1fr 1.2fr;
   align-items: center;
@@ -67,6 +176,7 @@ const ListRow = styled.div`
   padding: 16px 24px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.border.border1};
   transition: background-color 0.2s ease-in-out;
+  opacity: ${({ isDragging }) => (isDragging ? 0.5 : 1)};
 
   &:last-of-type {
     border-bottom: none;
@@ -74,6 +184,14 @@ const ListRow = styled.div`
 
   &:not(:first-of-type):hover {
     background-color: #f5f5f5;
+  }
+
+  &:not(:first-of-type) {
+    cursor: grab;
+  }
+
+  &:not(:first-of-type):active {
+    cursor: grabbing;
   }
 `;
 
@@ -188,6 +306,24 @@ interface QuestionSetApiResponse {
   questionSets: QuestionSets;
 }
 
+const FOLDER_COLORS = [
+  { bg: '#3b82f6', hover: '#2563eb' }, // 파란색
+  { bg: '#10b981', hover: '#059669' }, // 초록색
+  { bg: '#8b5cf6', hover: '#7c3aed' }, // 보라색
+  { bg: '#f59e0b', hover: '#d97706' }, // 주황색
+  { bg: '#ec4899', hover: '#db2777' }, // 분홍색
+  { bg: '#06b6d4', hover: '#0891b2' }, // 청록색
+  { bg: '#ef4444', hover: '#dc2626' }, // 빨간색
+  { bg: '#6366f1', hover: '#4f46e5' }, // 인디고
+  { bg: '#14b8a6', hover: '#0d9488' }, // 틸
+  { bg: '#f97316', hover: '#ea580c' }, // 오렌지
+];
+
+const getFolderColor = (folderId: number) => {
+  const index = folderId % FOLDER_COLORS.length;
+  return FOLDER_COLORS[index];
+};
+
 const Library = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
@@ -195,6 +331,10 @@ const Library = () => {
   const [editingTitle, setEditingTitle] = useState('');
   const [isVisibleMenu, setIsVisibleMenu] = useState<boolean>(false);
   const [selectedCell, setSelectedCell] = useState<QuestionSetContentType | null>(null);
+  const [draggedItem, setDraggedItem] = useState<QuestionSetContentType | null>(null);
+  const [dragOverFolderId, setDragOverFolderId] = useState<number | null>(null);
+  const [isAddingFolder, setIsAddingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
 
   const [mousePoint, setMousePoint] = useState<{
     x: number;
@@ -244,6 +384,38 @@ const Library = () => {
     },
     onError: (error) => {
       alert(`삭제 중 에러가 발생했습니다: ${error.message}`);
+    },
+  });
+
+  const moveFolderMutation = useMutation({
+    mutationFn: ({ questionSetId, folderId }: { questionSetId: number; folderId: number }) => {
+      return api.patch(`/question-set/${questionSetId}`, {
+        commonFolderId: folderId,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['folders'] });
+      queryClient.invalidateQueries({ queryKey: ['questionSets'] });
+    },
+    onError: (error) => {
+      alert(`폴더 이동 중 에러가 발생했습니다: ${error.message}`);
+    },
+  });
+
+  const createFolderMutation = useMutation({
+    mutationFn: (name: string) => {
+      return api.post('/common-folders', {
+        name,
+        type: QUESTION_SET_TYPE,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['folders'] });
+      setIsAddingFolder(false);
+      setNewFolderName('');
+    },
+    onError: (error) => {
+      alert(`폴더 생성 중 에러가 발생했습니다: ${error.message}`);
     },
   });
 
@@ -300,6 +472,65 @@ const Library = () => {
         : false,
   });
 
+  const { data: folders, isPending: isFoldersPending } = useQuery({
+    queryKey: ['folders'],
+    queryFn: async () => {
+      const res = await api.get<Folder[]>(`/common-folders?type=${QUESTION_SET_TYPE}`);
+      return res.data.sort((a, b) => a.sortOrder - b.sortOrder);
+    },
+  });
+
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, item: QuestionSetContentType) => {
+    setDraggedItem(item);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragEnd = () => {
+    setDraggedItem(null);
+    setDragOverFolderId(null);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>, folderId: number) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverFolderId(folderId);
+  };
+
+  const handleDragLeave = () => {
+    setDragOverFolderId(null);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, folder: Folder) => {
+    e.preventDefault();
+    setDragOverFolderId(null);
+
+    if (!draggedItem) return;
+
+    moveFolderMutation.mutate({
+      questionSetId: draggedItem.questionSetId,
+      folderId: folder.id,
+    });
+
+    setDraggedItem(null);
+  };
+
+  const handleAddFolder = () => {
+    setIsAddingFolder(true);
+  };
+
+  const handleCancelAddFolder = () => {
+    setIsAddingFolder(false);
+    setNewFolderName('');
+  };
+
+  const handleConfirmAddFolder = () => {
+    if (!newFolderName.trim()) {
+      alert('폴더 이름을 입력해주세요.');
+      return;
+    }
+    createFolderMutation.mutate(newFolderName.trim());
+  };
+
   const handleMenuRename = useCallback(() => {
     if (!selectedCell) return;
     handleRenameClick(selectedCell);
@@ -318,7 +549,7 @@ const Library = () => {
     setIsVisibleMenu(false);
   }, [selectedCell, handleSolveClick]);
 
-  if (isPending) {
+  if (isPending || isFoldersPending) {
     return <Spinner />;
   }
 
@@ -364,6 +595,49 @@ const Library = () => {
           onChange={(e) => setSearchTerm(e.target.value)}
         />
         <Spacer height="12px" />
+        <FolderContainer>
+          {folders &&
+            folders.map((folder) => {
+              const colors = getFolderColor(folder.id);
+              return (
+                <FolderTag
+                  key={folder.id}
+                  isDragOver={dragOverFolderId === folder.id}
+                  folderColor={colors.bg}
+                  folderHoverColor={colors.hover}
+                  onDragOver={(e) => handleDragOver(e, folder.id)}
+                  onDragLeave={handleDragLeave}
+                  onDrop={(e) => handleDrop(e, folder)}
+                >
+                  📁 {folder.name}
+                </FolderTag>
+              );
+            })}
+          {isAddingFolder ? (
+            <FolderInputContainer>
+              <span>📁</span>
+              <FolderInput
+                value={newFolderName}
+                onChange={(e) => setNewFolderName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleConfirmAddFolder();
+                  }
+                  if (e.key === 'Escape') {
+                    handleCancelAddFolder();
+                  }
+                }}
+                placeholder="폴더 이름"
+                autoFocus
+              />
+              <FolderActionButton onClick={handleConfirmAddFolder}>✔️</FolderActionButton>
+              <FolderActionButton onClick={handleCancelAddFolder}>❌</FolderActionButton>
+            </FolderInputContainer>
+          ) : (
+            <AddFolderButton onClick={handleAddFolder}>➕ 폴더 추가</AddFolderButton>
+          )}
+        </FolderContainer>
+        <Spacer height="12px" />
         {/* 여기에서 부터 리스트 박스입니다.*/}
         <ListBox>
           <ListRow>
@@ -381,7 +655,14 @@ const Library = () => {
               const isEditing = editingItemId === item.questionSetId;
 
               return (
-                <ListRow key={item.questionSetId} onContextMenu={(e) => handleContextMenu(e, item)}>
+                <ListRow
+                  key={item.questionSetId}
+                  draggable={item.status === 'COMPLETE'}
+                  isDragging={draggedItem?.questionSetId === item.questionSetId}
+                  onDragStart={(e) => handleDragStart(e, item)}
+                  onDragEnd={handleDragEnd}
+                  onContextMenu={(e) => handleContextMenu(e, item)}
+                >
                   <ListCell align="left">
                     {isEditing ? (
                       <TitleContainer>

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -339,8 +339,17 @@ const Library = () => {
   const [isAddingFolder, setIsAddingFolder] = useState(false);
   const [newFolderName, setNewFolderName] = useState('');
   const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
+  const [isVisibleFolderMenu, setIsVisibleFolderMenu] = useState<boolean>(false);
+  const [selectedFolder, setSelectedFolder] = useState<Folder | null>(null);
+  const [editingFolderId, setEditingFolderId] = useState<number | null>(null);
+  const [editingFolderName, setEditingFolderName] = useState('');
 
   const [mousePoint, setMousePoint] = useState<{
+    x: number;
+    y: number;
+  }>({ x: 0, y: 0 });
+
+  const [folderMousePoint, setFolderMousePoint] = useState<{
     x: number;
     y: number;
   }>({ x: 0, y: 0 });
@@ -357,6 +366,18 @@ const Library = () => {
     setSelectedCell(item);
     setIsVisibleMenu(true);
     setMousePoint({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleFolderContextMenu = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    folder: Folder,
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setSelectedFolder(folder);
+    setIsVisibleFolderMenu(true);
+    setFolderMousePoint({ x: e.clientX, y: e.clientY });
   };
 
   const updateTitleMutation = useMutation({
@@ -420,6 +441,39 @@ const Library = () => {
     },
     onError: (error) => {
       alert(`폴더 생성 중 에러가 발생했습니다: ${error.message}`);
+    },
+  });
+
+  const deleteFolderMutation = useMutation({
+    mutationFn: (id: number) => {
+      return api.delete(`/common-folders/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['folders'] });
+      queryClient.invalidateQueries({ queryKey: ['questionSets'] });
+      if (selectedFolderId === selectedFolder?.id) {
+        setSelectedFolderId(null);
+      }
+    },
+    onError: (error) => {
+      alert(`폴더 삭제 중 에러가 발생했습니다: ${error.message}`);
+    },
+  });
+
+  const updateFolderNameMutation = useMutation({
+    mutationFn: ({ id, name }: { id: number; name: string }) => {
+      if (!name.trim()) {
+        throw new Error('폴더 이름은 비워둘 수 없습니다.');
+      }
+      return api.patch(`/common-folders/${id}`, { name, type: QUESTION_SET_TYPE });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['folders'] });
+      setEditingFolderId(null);
+      setEditingFolderName('');
+    },
+    onError: (error) => {
+      alert(error.message);
     },
   });
 
@@ -573,6 +627,44 @@ const Library = () => {
     setIsVisibleMenu(false);
   }, [selectedCell, handleSolveClick]);
 
+  const handleFolderMenuRename = useCallback(() => {
+    if (!selectedFolder) return;
+    setEditingFolderId(selectedFolder.id);
+    setEditingFolderName(selectedFolder.name);
+    setIsVisibleFolderMenu(false);
+  }, [selectedFolder]);
+
+  const handleFolderMenuDelete = useCallback(async () => {
+    if (!selectedFolder) return;
+    setIsVisibleFolderMenu(false);
+
+    try {
+      const response = await api.get<{ questionSetCount: number }>(
+        `/common-folders/${selectedFolder.id}/delete-warning`,
+      );
+
+      const questionSetCount = response.data.questionSetCount;
+      const confirmMessage =
+        questionSetCount > 0
+          ? `'${selectedFolder.name}' 폴더에 ${questionSetCount}개의 문제집이 있습니다.\n정말로 삭제하시겠습니까?`
+          : `'${selectedFolder.name}' 폴더를 정말 삭제하시겠습니까?`;
+
+      if (window.confirm(confirmMessage)) {
+        deleteFolderMutation.mutate(selectedFolder.id);
+      }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : '알 수 없는 오류';
+      alert(`폴더 삭제 경고 정보를 가져오는데 실패했습니다: ${errorMessage}`);
+    }
+  }, [selectedFolder, deleteFolderMutation]);
+
+  const submitFolderNameEdit = (folder: Folder) => {
+    updateFolderNameMutation.mutate({
+      id: folder.id,
+      name: editingFolderName,
+    });
+  };
+
   if (isPending || isFoldersPending) {
     return <Spinner />;
   }
@@ -609,6 +701,14 @@ const Library = () => {
           disabled={selectedCell?.status !== 'COMPLETE'}
         />
       </RightClickMenu>
+      <RightClickMenu
+        isVisible={isVisibleFolderMenu}
+        setIsVisible={setIsVisibleFolderMenu}
+        point={folderMousePoint}
+      >
+        <RightClickMenuItem icon="✏️" title="폴더 이름 변경" onClick={handleFolderMenuRename} />
+        <RightClickMenuItem icon="❌" title="폴더 삭제" onClick={handleFolderMenuDelete} />
+      </RightClickMenu>
       <LibraryWrapper>
         <LibraryTitle />
         <LibraryProgressSummary percent={data?.learningProgress ?? 0} />
@@ -624,6 +724,7 @@ const Library = () => {
           {folders &&
             folders.map((folder) => {
               const colors = getFolderColor(folder.id);
+              const isEditingThisFolder = editingFolderId === folder.id;
               return (
                 <FolderTag
                   key={folder.id}
@@ -632,11 +733,48 @@ const Library = () => {
                   folderColor={colors.bg}
                   folderHoverColor={colors.hover}
                   onClick={() => handleFolderClick(folder.id)}
+                  onContextMenu={(e) => handleFolderContextMenu(e, folder)}
                   onDragOver={(e) => handleDragOver(e, folder.id)}
                   onDragLeave={handleDragLeave}
                   onDrop={(e) => handleDrop(e, folder)}
                 >
-                  📁 {folder.name}
+                  {isEditingThisFolder ? (
+                    <>
+                      📁{' '}
+                      <FolderInput
+                        value={editingFolderName}
+                        onChange={(e) => setEditingFolderName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            submitFolderNameEdit(folder);
+                          }
+                          if (e.key === 'Escape') {
+                            setEditingFolderId(null);
+                          }
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                        autoFocus
+                      />
+                      <FolderActionButton
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          submitFolderNameEdit(folder);
+                        }}
+                      >
+                        ✔️
+                      </FolderActionButton>
+                      <FolderActionButton
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setEditingFolderId(null);
+                        }}
+                      >
+                        ❌
+                      </FolderActionButton>
+                    </>
+                  ) : (
+                    <>📁 {folder.name}</>
+                  )}
                 </FolderTag>
               );
             })}

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -25,6 +25,7 @@ interface Folder {
 }
 
 const QUESTION_SET_TYPE = 'QUESTION_SET';
+const ALL_FOLDER_ID = 1;
 
 const Container = styled.div`
   display: flex;
@@ -781,8 +782,18 @@ const Library = () => {
         setIsVisible={setIsVisibleFolderMenu}
         point={folderMousePoint}
       >
-        <RightClickMenuItem icon="✏️" title="폴더 이름 변경" onClick={handleFolderMenuRename} />
-        <RightClickMenuItem icon="❌" title="폴더 삭제" onClick={handleFolderMenuDelete} />
+        <RightClickMenuItem
+          icon="✏️"
+          title="폴더 이름 변경"
+          onClick={handleFolderMenuRename}
+          disabled={selectedFolder?.id === ALL_FOLDER_ID}
+        />
+        <RightClickMenuItem
+          icon="❌"
+          title="폴더 삭제"
+          onClick={handleFolderMenuDelete}
+          disabled={selectedFolder?.id === ALL_FOLDER_ID}
+        />
       </RightClickMenu>
       <LibraryWrapper>
         <LibraryTitle />

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -885,7 +885,7 @@ const Library = () => {
               <FolderActionButton onClick={handleCancelAddFolder}>❌</FolderActionButton>
             </FolderInputContainer>
           ) : (
-            <AddFolderButton onClick={handleAddFolder}>➕ 폴더 추가</AddFolderButton>
+            <AddFolderButton onClick={handleAddFolder}>➕</AddFolderButton>
           )}
         </FolderContainer>
         <Spacer height="12px" />

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -70,21 +70,24 @@ const FolderTag = styled.div<{
   isDragOver?: boolean;
   folderColor: string;
   folderHoverColor: string;
+  isActive?: boolean;
 }>`
   display: inline-flex;
   align-items: center;
   padding: 6px 12px;
   border-radius: ${({ theme }) => theme.radius.radius2};
-  background-color: ${({ isDragOver, folderColor, folderHoverColor }) =>
-    isDragOver ? folderHoverColor : folderColor};
+  background-color: ${({ isDragOver, folderColor, folderHoverColor, isActive }) =>
+    isDragOver || isActive ? folderHoverColor : folderColor};
   border: 1px solid
-    ${({ isDragOver, folderHoverColor }) => (isDragOver ? folderHoverColor : 'transparent')};
+    ${({ isDragOver, folderHoverColor, isActive }) =>
+      isDragOver || isActive ? folderHoverColor : 'transparent'};
   font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
   color: white;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
   user-select: none;
-  font-weight: 500;
+  font-weight: ${({ isActive }) => (isActive ? '700' : '500')};
+  box-shadow: ${({ isActive }) => (isActive ? '0 2px 8px rgba(0, 0, 0, 0.15)' : 'none')};
 
   &:hover {
     background-color: ${({ folderHoverColor }) => folderHoverColor};
@@ -335,6 +338,7 @@ const Library = () => {
   const [dragOverFolderId, setDragOverFolderId] = useState<number | null>(null);
   const [isAddingFolder, setIsAddingFolder] = useState(false);
   const [newFolderName, setNewFolderName] = useState('');
+  const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
 
   const [mousePoint, setMousePoint] = useState<{
     x: number;
@@ -366,7 +370,7 @@ const Library = () => {
       return api.patch(`/question-set/${id}`, { title });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['questionSets'] });
+      queryClient.invalidateQueries({ queryKey: ['questionSets', selectedFolderId] });
       setEditingItemId(null);
       setEditingTitle('');
     },
@@ -380,7 +384,7 @@ const Library = () => {
       return api.delete(`/question-set/${id}`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['questionSets'] });
+      queryClient.invalidateQueries({ queryKey: ['questionSets', selectedFolderId] });
     },
     onError: (error) => {
       alert(`삭제 중 에러가 발생했습니다: ${error.message}`);
@@ -460,24 +464,40 @@ const Library = () => {
     };
   }, [searchTerm]);
 
-  const { isPending, error, data } = useQuery({
-    queryKey: ['questionSets'],
-    queryFn: async () => {
-      const res = await api.get<QuestionSetApiResponse>(`/question-set`);
-      return res.data;
-    },
-    refetchInterval: (query) =>
-      query.state.data?.questionSets.content.some((item) => item.status === 'PENDING')
-        ? 5000
-        : false,
-  });
-
   const { data: folders, isPending: isFoldersPending } = useQuery({
     queryKey: ['folders'],
     queryFn: async () => {
       const res = await api.get<Folder[]>(`/common-folders?type=${QUESTION_SET_TYPE}`);
       return res.data.sort((a, b) => a.sortOrder - b.sortOrder);
     },
+  });
+
+  // 폴더가 로드되면 첫 번째 폴더를 자동 선택
+  useEffect(() => {
+    if (folders && folders.length > 0 && selectedFolderId === null) {
+      setSelectedFolderId(folders[0].id);
+    }
+  }, [folders, selectedFolderId]);
+
+  const { isPending, error, data } = useQuery({
+    queryKey: ['questionSets', selectedFolderId],
+    queryFn: async () => {
+      if (selectedFolderId === null) {
+        return {
+          learningProgress: 0,
+          questionSets: { content: [], nextCursor: 0, hasNext: false, size: 0 },
+        };
+      }
+      const res = await api.get<QuestionSetApiResponse>(
+        `/question-set?size=9999&folderId=${selectedFolderId}`,
+      );
+      return res.data;
+    },
+    enabled: selectedFolderId !== null,
+    refetchInterval: (query) =>
+      query.state.data?.questionSets.content.some((item) => item.status === 'PENDING')
+        ? 5000
+        : false,
   });
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>, item: QuestionSetContentType) => {
@@ -531,6 +551,10 @@ const Library = () => {
     createFolderMutation.mutate(newFolderName.trim());
   };
 
+  const handleFolderClick = (folderId: number) => {
+    setSelectedFolderId(folderId);
+  };
+
   const handleMenuRename = useCallback(() => {
     if (!selectedCell) return;
     handleRenameClick(selectedCell);
@@ -557,9 +581,10 @@ const Library = () => {
     return <span>에러가 발생했습니다: {error.message}</span>;
   }
 
-  const filteredQuestionSets = data.questionSets.content.filter((item) =>
-    item.title.toLowerCase().includes(debouncedSearchTerm.toLowerCase()),
-  );
+  const filteredQuestionSets =
+    data?.questionSets.content.filter((item) =>
+      item.title.toLowerCase().includes(debouncedSearchTerm.toLowerCase()),
+    ) ?? [];
 
   return (
     <Container>
@@ -586,7 +611,7 @@ const Library = () => {
       </RightClickMenu>
       <LibraryWrapper>
         <LibraryTitle />
-        <LibraryProgressSummary percent={data.learningProgress} />
+        <LibraryProgressSummary percent={data?.learningProgress ?? 0} />
         <Spacer height="12px" />
         {/* 검색 input창 -> 디바운싱 구현되어 있습니다. */}
         <FileListSearchInput
@@ -603,8 +628,10 @@ const Library = () => {
                 <FolderTag
                   key={folder.id}
                   isDragOver={dragOverFolderId === folder.id}
+                  isActive={selectedFolderId === folder.id}
                   folderColor={colors.bg}
                   folderHoverColor={colors.hover}
+                  onClick={() => handleFolderClick(folder.id)}
                   onDragOver={(e) => handleDragOver(e, folder.id)}
                   onDragLeave={handleDragLeave}
                   onDrop={(e) => handleDrop(e, folder)}


### PR DESCRIPTION
## PR 설명

- 나의 문제집 폴더 구현

## 작업 상세 내용

- 폴더 목록
<img width="1352" height="676" alt="image" src="https://github.com/user-attachments/assets/b944983b-4692-41ce-98ae-eb0ed8227026" />

- 폴더 추가 (+버튼 클릭시)
<img width="548" height="101" alt="image" src="https://github.com/user-attachments/assets/630f6e83-2034-467f-8dc5-4df5389f5053" />

- 우클릭
<img width="472" height="163" alt="image" src="https://github.com/user-attachments/assets/983ec637-7430-428f-92ef-d1c656fb9025" />

- 삭제시
<img width="468" height="176" alt="image" src="https://github.com/user-attachments/assets/5e3292c0-0e15-46fe-aeef-ad7a23c8c914" />
(확인 누르면 문제집도 삭제)

- 폴더명 변경
<img width="209" height="75" alt="image" src="https://github.com/user-attachments/assets/b61eb0ff-628f-43d8-8a69-2a1c1bb649e9" />

- 폴더 이동 (문제집 우클릭)
<img width="602" height="274" alt="image" src="https://github.com/user-attachments/assets/0d1b2089-c090-453e-85da-7d65c43ca611" />


그 외
- 폴더 이동 (드래그 앤 드랍)
- 폴더 클릭시 해당 폴더의 문제집만 로드


## 기타사항 / 참고사항

- 앞에 폴더 아이콘은 없앨까 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder organization system for managing question sets
  * Create, edit, and delete folders
  * Drag-and-drop support to move question sets into folders
  * Color-coded folder display for easy identification
  * Right-click context menu for folder management operations
  * Move question sets between folders via context menu selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->