### PR TITLE
FTSK-92: 오답노트 페이지에 폴더 임시로 이식 및 참거짓 정답 출력 안되는 문제수정, 문제풀이 페이지에 제출하기 버튼 추가

### DIFF
--- a/src/app/auth/AuthProvider.tsx
+++ b/src/app/auth/AuthProvider.tsx
@@ -27,7 +27,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           const userData = await getUserInfo();
           setUser(userData);
         } else {
-          console.log('유효한 토큰이 없어 비로그인 상태로 처리합니다');
+          // console.log('유효한 토큰이 없어 비로그인 상태로 처리합니다');
         }
       } catch (error) {
         // 사용자 정보 조회 실패 시에만 에러 로그 출력

--- a/src/features/dashboard/components/CalendarHeatmapCompo.tsx
+++ b/src/features/dashboard/components/CalendarHeatmapCompo.tsx
@@ -39,7 +39,6 @@ function CalendarHeatmapCompo({ values, startDate, endDate }: Props) {
         values={values}
         titleForValue={(value: unknown) => {
           const v = value as DailyStatItem | undefined;
-          // console.log(value);
           if (!v) {
             return '';
           }

--- a/src/features/solve/components/ProgressCard.tsx
+++ b/src/features/solve/components/ProgressCard.tsx
@@ -55,7 +55,7 @@ const SubmitBtn = styled.button`
   background-color: ${({ theme }) => theme.colors.semantic.primary};
   padding: ${({ theme }) => theme.spacing.spacing2} ${({ theme }) => theme.spacing.spacing4};
   border-radius: ${({ theme }) => theme.radius.radius1};
-`
+`;
 type ProgressCardProps = {
   questionLength: number;
   solvedCheck: MarkingRequest[];
@@ -63,15 +63,16 @@ type ProgressCardProps = {
   setIsAllSolved: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-function ProgressCard({ questionLength, solvedCheck, questions, setIsAllSolved }: ProgressCardProps) {
+function ProgressCard({
+  questionLength,
+  solvedCheck,
+  questions,
+  setIsAllSolved,
+}: ProgressCardProps) {
   const goResult = () => {
-    if (
-      solvedCheck.length === questions.questions.length
-    ) {
+    if (solvedCheck.length === questions.questions.length) {
       setIsAllSolved(true);
-    } else if (
-      solvedCheck.length !== questions.questions.length
-    ) {
+    } else if (solvedCheck.length !== questions.questions.length) {
       toast('모든 문제를 체크해야 넘어갈 수 있습니다');
     }
   };

--- a/src/features/solve/components/ProgressCard.tsx
+++ b/src/features/solve/components/ProgressCard.tsx
@@ -72,7 +72,7 @@ function ProgressCard({
   const goResult = () => {
     if (solvedCheck.length === questions.questions.length) {
       setIsAllSolved(true);
-    } else if (solvedCheck.length !== questions.questions.length) {
+    } else {
       toast('모든 문제를 체크해야 넘어갈 수 있습니다');
     }
   };

--- a/src/features/solve/components/ProgressCard.tsx
+++ b/src/features/solve/components/ProgressCard.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 import type { MarkingRequest } from '../types/MarkingRequest';
+import { toast } from 'react-toastify';
+import type { QuestionSet } from '@/features/solve/types/question';
 
 const ProgressCardWrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.gray.gray0};
@@ -9,6 +11,9 @@ const ProgressCardWrapper = styled.div`
   border-radius: ${({ theme }) => theme.radius.radius2};
 
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 `;
 
 const CardTitle = styled.h6`
@@ -42,11 +47,34 @@ const ProgressStatValue = styled.span`
   line-height: ${({ theme }) => theme.typography.label2Regular.lineHeight};
 `;
 
+const SubmitBtn = styled.button`
+  font-size: ${({ theme }) => theme.typography.label1Regular.fontSize};
+  font-weight: ${({ theme }) => theme.typography.label1Regular.fontWeight};
+  line-height: ${({ theme }) => theme.typography.label1Regular.lineHeight};
+  color: ${({ theme }) => theme.colors.gray.gray0};
+  background-color: ${({ theme }) => theme.colors.semantic.primary};
+  padding: ${({ theme }) => theme.spacing.spacing2} ${({ theme }) => theme.spacing.spacing4};
+  border-radius: ${({ theme }) => theme.radius.radius1};
+`
 type ProgressCardProps = {
   questionLength: number;
   solvedCheck: MarkingRequest[];
+  questions: QuestionSet;
+  setIsAllSolved: React.Dispatch<React.SetStateAction<boolean>>;
 };
-function ProgressCard({ questionLength, solvedCheck }: ProgressCardProps) {
+
+function ProgressCard({ questionLength, solvedCheck, questions, setIsAllSolved }: ProgressCardProps) {
+  const goResult = () => {
+    if (
+      solvedCheck.length === questions.questions.length
+    ) {
+      setIsAllSolved(true);
+    } else if (
+      solvedCheck.length !== questions.questions.length
+    ) {
+      toast('모든 문제를 체크해야 넘어갈 수 있습니다');
+    }
+  };
   return (
     <ProgressCardWrapper>
       <CardTitle>진행 현황</CardTitle>
@@ -64,6 +92,7 @@ function ProgressCard({ questionLength, solvedCheck }: ProgressCardProps) {
           <ProgressStatValue>{questionLength - solvedCheck.length}</ProgressStatValue>
         </ProgressStatItem>
       </ProgressStats>
+      <SubmitBtn onClick={goResult}>제출하기</SubmitBtn>
     </ProgressCardWrapper>
   );
 }

--- a/src/features/solve/components/question-types/TrueFalseSolve.tsx
+++ b/src/features/solve/components/question-types/TrueFalseSolve.tsx
@@ -220,7 +220,9 @@ function TrueFalseSolve({
         {isExplanationPage && (
           <ExplanationBox>
             <ExplanationBoxTitle>정답 및 해설</ExplanationBoxTitle>
-            <AnswerTxt>정답 : {questions.questions[currentQuestionIndex - 1].answer ? "참" : "거짓"}</AnswerTxt>
+            <AnswerTxt>
+              정답 : {questions.questions[currentQuestionIndex - 1].answer ? '참' : '거짓'}
+            </AnswerTxt>
             <ExplanationTxt>
               {questions.questions[currentQuestionIndex - 1].explanation}
             </ExplanationTxt>

--- a/src/features/solve/components/question-types/TrueFalseSolve.tsx
+++ b/src/features/solve/components/question-types/TrueFalseSolve.tsx
@@ -184,6 +184,7 @@ function TrueFalseSolve({
     }
   }, [currentQuestionIndex, solvedCheck, questions]);
 
+  console.log(questions.questions[currentQuestionIndex - 1]);
   return (
     <QuestionAreaWrapper>
       <QuestionAreaHeader>
@@ -219,7 +220,7 @@ function TrueFalseSolve({
         {isExplanationPage && (
           <ExplanationBox>
             <ExplanationBoxTitle>정답 및 해설</ExplanationBoxTitle>
-            <AnswerTxt>정답 : {questions.questions[currentQuestionIndex - 1].answer}</AnswerTxt>
+            <AnswerTxt>정답 : {questions.questions[currentQuestionIndex - 1].answer ? "참" : "거짓"}</AnswerTxt>
             <ExplanationTxt>
               {questions.questions[currentQuestionIndex - 1].explanation}
             </ExplanationTxt>

--- a/src/features/solve/components/question-types/TrueFalseSolve.tsx
+++ b/src/features/solve/components/question-types/TrueFalseSolve.tsx
@@ -184,7 +184,6 @@ function TrueFalseSolve({
     }
   }, [currentQuestionIndex, solvedCheck, questions]);
 
-  console.log(questions.questions[currentQuestionIndex - 1]);
   return (
     <QuestionAreaWrapper>
       <QuestionAreaHeader>

--- a/src/features/wrong/components/WrongNoteListItem.tsx
+++ b/src/features/wrong/components/WrongNoteListItem.tsx
@@ -96,7 +96,7 @@ function WrongNoteListItem({ item }: WrongNoteListItemProps) {
       </WrongNoteInfoTitleWrapper>
       <WrongCount>{item.incorrectCount}개</WrongCount>
       <DifficultyLevel>{item.difficulty}</DifficultyLevel>
-      <CategoryType>{"전체"}</CategoryType>
+      <CategoryType>{'전체'}</CategoryType>
       <RetryBtn onClick={handleReviewNavigate}>복습하기</RetryBtn>
     </WrongNoteListItemWrapper>
   );

--- a/src/features/wrong/components/WrongNoteListItem.tsx
+++ b/src/features/wrong/components/WrongNoteListItem.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { BookOpen } from 'lucide-react';
 // import type { WrongNoteSetResponse } from '@/features/wrong/types/wrongNote';
 import { useNavigate } from 'react-router-dom';
 const WrongNoteListItemWrapper = styled.div`
@@ -11,21 +10,10 @@ const WrongNoteListItemWrapper = styled.div`
   display: grid;
   grid-template-columns: 3fr 1fr 1fr 1fr 1fr;
   align-items: center;
-`;
 
-const WrongNoteInfoWrapper = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-const IconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 36px;
-  height: 36px;
-  border-radius: ${({ theme }) => theme.radius.radius2};
-  background-color: ${({ theme }) => theme.colors.green.green2};
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray.gray2};
+  }
 `;
 
 const WrongNoteInfoTitleWrapper = styled.div`
@@ -35,9 +23,9 @@ const WrongNoteInfoTitleWrapper = styled.div`
 `;
 
 const WrongNoteTitle = styled.span`
-  font-size: ${({ theme }) => theme.typography.label1Bold.fontSize};
-  font-weight: ${({ theme }) => theme.typography.label1Bold.fontWeight};
-  line-height: ${({ theme }) => theme.typography.label1Bold.lineHeight};
+  font-size: ${({ theme }) => theme.typography.label1Regular.fontSize};
+  font-weight: ${({ theme }) => theme.typography.label1Regular.fontWeight};
+  line-height: ${({ theme }) => theme.typography.label1Regular.lineHeight};
 `;
 
 const WrongNoteFileName = styled.span`
@@ -56,22 +44,16 @@ const DifficultyLevel = styled.span`
   font-size: ${({ theme }) => theme.typography.label2Regular.fontSize};
   font-weight: ${({ theme }) => theme.typography.label2Regular.fontWeight};
   line-height: ${({ theme }) => theme.typography.label2Regular.lineHeight};
-  background-color: ${({ theme }) => theme.colors.red.red0};
-  color: ${({ theme }) => theme.colors.red.red3};
   border-radius: ${({ theme }) => theme.radius.radius2};
   width: fit-content;
-  padding: ${({ theme }) => theme.spacing.spacing1} ${({ theme }) => theme.spacing.spacing2};
 `;
 
 const CategoryType = styled.span`
   font-size: ${({ theme }) => theme.typography.label2Regular.fontSize};
   font-weight: ${({ theme }) => theme.typography.label2Regular.fontWeight};
   line-height: ${({ theme }) => theme.typography.label2Regular.lineHeight};
-  background-color: ${({ theme }) => theme.colors.blue.blue0};
-  color: ${({ theme }) => theme.colors.blue.blue2};
   border-radius: ${({ theme }) => theme.radius.radius2};
   width: fit-content;
-  padding: ${({ theme }) => theme.spacing.spacing1} ${({ theme }) => theme.spacing.spacing2};
 `;
 
 const RetryBtn = styled.button`
@@ -108,18 +90,13 @@ function WrongNoteListItem({ item }: WrongNoteListItemProps) {
 
   return (
     <WrongNoteListItemWrapper>
-      <WrongNoteInfoWrapper>
-        <IconWrapper>
-          <BookOpen color="green" size={16} />
-        </IconWrapper>
-        <WrongNoteInfoTitleWrapper>
-          <WrongNoteTitle>{item.questionSetTitle}</WrongNoteTitle>
-          <WrongNoteFileName>{item.sourceNames[0]}</WrongNoteFileName>
-        </WrongNoteInfoTitleWrapper>
-      </WrongNoteInfoWrapper>
+      <WrongNoteInfoTitleWrapper>
+        <WrongNoteTitle>{item.questionSetTitle}</WrongNoteTitle>
+        <WrongNoteFileName>{item.sourceNames[0]}</WrongNoteFileName>
+      </WrongNoteInfoTitleWrapper>
       <WrongCount>{item.incorrectCount}개</WrongCount>
       <DifficultyLevel>{item.difficulty}</DifficultyLevel>
-      <CategoryType>{'수학'}</CategoryType>
+      <CategoryType>{"전체"}</CategoryType>
       <RetryBtn onClick={handleReviewNavigate}>복습하기</RetryBtn>
     </WrongNoteListItemWrapper>
   );

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -172,7 +172,12 @@ function Solve() {
             <SolveContentWrapper>
               {renderSolveComponent()}
               <RightSidebar>
-                <ProgressCard questionLength={data.questions.length} solvedCheck={solvedCheck} questions={data} setIsAllSolved={setIsAllSolved}/>
+                <ProgressCard
+                  questionLength={data.questions.length}
+                  solvedCheck={solvedCheck}
+                  questions={data}
+                  setIsAllSolved={setIsAllSolved}
+                />
               </RightSidebar>
             </SolveContentWrapper>
           </>

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -63,7 +63,6 @@ function Solve() {
   }; // 해설 보러 가는 wrapper 함수
   const isReviewing = searchParams.get('isReviewing') === 'true';
 
-  console.log('풀고있는 문제 state', solvedCheck);
   // 1. 서버로부터 문제조회를 하는 부분 questionSetId로 문제집 조회
   const { isPending, error, data } = useQuery({
     queryKey: ['questionSet', questionSetId, isReviewing],

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -172,7 +172,7 @@ function Solve() {
             <SolveContentWrapper>
               {renderSolveComponent()}
               <RightSidebar>
-                <ProgressCard questionLength={data.questions.length} solvedCheck={solvedCheck} />
+                <ProgressCard questionLength={data.questions.length} solvedCheck={solvedCheck} questions={data} setIsAllSolved={setIsAllSolved}/>
               </RightSidebar>
             </SolveContentWrapper>
           </>

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -151,7 +151,7 @@ function Wrong() {
     }
   }, [folders, selectedFolderId]);
 
-  // 선택된 폴더에 포함된 문제집 목록 조회 (ID만 필요)
+  // 선택된 폴더에 포함된 문제집 목록 조회 (ID만 필요) 이 부분 좀 이상함 
   const { data: questionSetsData } = useQuery({
     queryKey: ['questionSets', selectedFolderId],
     queryFn: async () => {

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -151,7 +151,7 @@ function Wrong() {
     }
   }, [folders, selectedFolderId]);
 
-  // 선택된 폴더에 포함된 문제집 목록 조회 (ID만 필요) 이 부분 좀 이상함 
+  // 선택된 폴더에 포함된 문제집 목록 조회 (ID만 필요) 이 부분 좀 이상함
   const { data: questionSetsData } = useQuery({
     queryKey: ['questionSets', selectedFolderId],
     queryFn: async () => {

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -71,10 +71,11 @@ const SearchBar = styled.input`
   font-size: ${({ theme }) => theme.typography.label1Regular.fontSize};
   font-weight: ${({ theme }) => theme.typography.label1Regular.fontWeight};
   line-height: ${({ theme }) => theme.typography.label1Regular.lineHeight};
-  padding: ${({ theme }) => theme.spacing.spacing2};
+  padding: ${({ theme }) => theme.spacing.spacing4};
 
   border: 1px solid ${({ theme }) => theme.colors.gray.gray3};
-  border-radius: ${({ theme }) => theme.radius.radius1};
+  border-radius: ${({ theme }) => theme.radius.radius2};
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
   &:focus {
     outline: none;
     border: 1px solid ${({ theme }) => theme.colors.semantic.primary};
@@ -86,24 +87,26 @@ const SearchBar = styled.input`
 const WrongNoteList = styled.div`
   display: flex;
   flex-direction: column;
-  border: 1px solid ${({ theme }) => theme.colors.gray.gray5};
-  border-radius: ${({ theme }) => theme.radius.radius2};
+  /* border: 1px solid ${({ theme }) => theme.colors.gray.gray5}; */
+  border-radius: ${({ theme }) => theme.radius.radius3};
   overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
 `;
 
 const WrongNoteListHeader = styled.div`
   display: grid;
   grid-template-columns: 3fr 1fr 1fr 1fr 1fr;
-  background-color: ${({ theme }) => theme.colors.gray.gray1};
-  /* align-items: center; */
-  padding: ${({ theme }) => theme.spacing.spacing3} ${({ theme }) => theme.spacing.spacing4};
-  /* border-bottom: 1px solid ${({ theme }) => theme.colors.gray.gray4}; */
-`;
-
-const WrongNoteListHeaderColumn = styled.span`
+  background-color: ${({ theme }) => theme.colors.gray.gray0};
+  padding: ${({ theme }) => theme.spacing.spacing5} ${({ theme }) => theme.spacing.spacing5};
   font-size: ${({ theme }) => theme.typography.label2Regular.fontSize};
   font-weight: ${({ theme }) => theme.typography.label2Regular.fontWeight};
   line-height: ${({ theme }) => theme.typography.label2Regular.lineHeight};
+`;
+
+const WrongNoteListHeaderColumn = styled.span`
+  font-size: ${({ theme }) => theme.typography.label2Bold.fontSize};
+  font-weight: ${({ theme }) => theme.typography.label2Bold.fontWeight};
+  line-height: ${({ theme }) => theme.typography.label2Bold.lineHeight};
   color: ${({ theme }) => theme.colors.gray.gray9};
 `;
 
@@ -163,9 +166,9 @@ function Wrong() {
           <WrongNoteListHeader>
             <WrongNoteListHeaderColumn>문제집</WrongNoteListHeaderColumn>
             <WrongNoteListHeaderColumn>오답 수</WrongNoteListHeaderColumn>
-            <WrongNoteListHeaderColumn>난이도</WrongNoteListHeaderColumn>
-            <WrongNoteListHeaderColumn>카테고리</WrongNoteListHeaderColumn>
-            <WrongNoteListHeaderColumn>작업</WrongNoteListHeaderColumn>
+            <WrongNoteListHeaderColumn>유형</WrongNoteListHeaderColumn>
+            <WrongNoteListHeaderColumn>폴더</WrongNoteListHeaderColumn>
+            <WrongNoteListHeaderColumn>오답노트</WrongNoteListHeaderColumn>
           </WrongNoteListHeader>
           {filteredQuestionSets?.map((item) => (
             <WrongNoteListItem key={item.questionSetId} item={item} />

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { WrongNoteSetResponse } from '@/features/wrong/types/wrongNote';
 import { useState, useEffect } from 'react';
 import Spinner from '@/shared/components/Spinner';
+import FolderList from '@/shared/components/FolderList';
 
 const WrongWrapper = styled.div`
   display: flex;
@@ -110,6 +111,20 @@ const WrongNoteListHeaderColumn = styled.span`
   color: ${({ theme }) => theme.colors.gray.gray9};
 `;
 
+// 폴더 관련 타입 + 인터페이스들
+const QUESTION_SET_TYPE = 'QUESTION_SET';
+const ALL_FOLDER_ID = 1;
+interface Folder {
+  id: number;
+  name: string;
+  type: 'QUESTION_SET';
+  sortOrder: number;
+}
+
+interface QuestionSetContent {
+  questionSetId: number;
+}
+
 function Wrong() {
   const { isPending, error, data } = useQuery({
     queryKey: ['wrongNoteSet', 'wrongNoteSetId'],
@@ -117,6 +132,36 @@ function Wrong() {
       const res = await api.get<WrongNoteSetResponse>(`/wrong-answers/all`);
       return res.data;
     },
+  });
+
+  // 폴더 목록 조회
+  const { data: folders } = useQuery({
+    queryKey: ['folders'],
+    queryFn: async () => {
+      const res = await api.get<Folder[]>(`/common-folders?type=${QUESTION_SET_TYPE}`);
+      return res.data.sort((a, b) => a.sortOrder - b.sortOrder);
+    },
+  });
+
+  const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (folders && folders.length > 0 && selectedFolderId === null) {
+      setSelectedFolderId(folders[0].id);
+    }
+  }, [folders, selectedFolderId]);
+
+  // 선택된 폴더에 포함된 문제집 목록 조회 (ID만 필요)
+  const { data: questionSetsData } = useQuery({
+    queryKey: ['questionSets', selectedFolderId],
+    queryFn: async () => {
+      if (selectedFolderId === null) {
+        return { questionSets: { content: [] as QuestionSetContent[] } };
+      }
+      const res = await api.get(`/question-set?size=9999&folderId=${selectedFolderId}`);
+      return res.data as { questionSets: { content: QuestionSetContent[] } };
+    },
+    enabled: selectedFolderId !== null,
   });
 
   const [searchTerm, setSearchTerm] = useState('');
@@ -134,8 +179,16 @@ function Wrong() {
 
   const normalize = (str: string) => str.toLowerCase().normalize('NFC').replace(/\s+/g, '');
 
-  const filteredQuestionSets = data?.filter((item) =>
-    normalize(item.questionSetTitle).includes(normalize(debouncedSearchTerm)),
+  const filteredQuestionSets = data?.filter(
+    (item) =>
+      normalize(item.questionSetTitle).includes(normalize(debouncedSearchTerm)) &&
+      // 폴더 필터 적용: 선택된 폴더가 없거나 ALL_FOLDER_ID이면 전체 표시
+      (selectedFolderId === null || selectedFolderId === ALL_FOLDER_ID
+        ? true
+        : // 선택된 폴더에 포함된 questionSetId인지 확인
+          (questionSetsData?.questionSets?.content || []).some(
+            (qs: { questionSetId: number }) => qs.questionSetId === item.questionSetId,
+          )),
   );
 
   // 로딩
@@ -162,6 +215,16 @@ function Wrong() {
             onChange={(e) => setSearchTerm(e.target.value)}
           />
         </SearchBarWrapper>
+        <FolderList
+          folders={folders}
+          selectedFolderId={selectedFolderId}
+          onFolderSelect={setSelectedFolderId}
+          // Wrong 페이지에서는 드래그로 문제집을 이동시키는 기능을 아직 사용하지 않으므로 null/noop 전달
+          draggedItem={null}
+          onItemDrop={() => {
+            /* noop */
+          }}
+        />
         <WrongNoteList>
           <WrongNoteListHeader>
             <WrongNoteListHeaderColumn>문제집</WrongNoteListHeaderColumn>

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -154,7 +154,7 @@ function Wrong() {
   // 선택된 폴더에 포함된 문제집 목록 조회 (ID만 필요) 이 부분 좀 이상함
   const { data: questionSetsData } = useQuery({
     queryKey: ['questionSets', selectedFolderId],
-        queryFn: async () => {
+    queryFn: async () => {
       const res = await api.get(`/question-set?size=9999&folderId=${selectedFolderId}`);
       return res.data as { questionSets: { content: QuestionSetContent[] } };
     },

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from 'react';
 import Spinner from '@/shared/components/Spinner';
 import FolderList from '@/shared/components/FolderList';
 
+// prettier 돌려줘
 const WrongWrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -154,10 +154,7 @@ function Wrong() {
   // 선택된 폴더에 포함된 문제집 목록 조회 (ID만 필요) 이 부분 좀 이상함
   const { data: questionSetsData } = useQuery({
     queryKey: ['questionSets', selectedFolderId],
-    queryFn: async () => {
-      if (selectedFolderId === null) {
-        return { questionSets: { content: [] as QuestionSetContent[] } };
-      }
+        queryFn: async () => {
       const res = await api.get(`/question-set?size=9999&folderId=${selectedFolderId}`);
       return res.data as { questionSets: { content: QuestionSetContent[] } };
     },

--- a/src/pages/layout/AppLayout.tsx
+++ b/src/pages/layout/AppLayout.tsx
@@ -68,10 +68,14 @@ function AppLayout() {
     const es = new NotificationSse();
     esRef.current = es;
 
-    es.onOpen(() => console.log('[SSE] 연결 성공 (Open)'));
-    es.onHandShake(() => console.log('[SSE] HandShake 완료'));
-    es.onError((e) => {
-      console.error('[SSE] 에러 발생:', e);
+    es.onOpen(() => {
+      // console.log('[SSE] 연결 성공 (Open)');
+    });
+    es.onHandShake(() => {
+      // console.log('[SSE] HandShake 완료');
+    });
+    es.onError(() => {
+      // console.error('[SSE] 에러 발생:', e);
       // EventSource는 자동으로 재연결을 시도합니다 (기본 동작)
     });
 


### PR DESCRIPTION
## PR 설명

- 오답노트 페이지에 폴더 임시로 이식 및 참거짓 정답 출력 안되는 문제수정, 문제풀이 페이지에 제출하기 버튼 추가

## 작업 상세 내용

- 참 거짓 정답보기에 정답이 출력안되는 문제 수정
- 문제풀이 페이지에 제출하기 버튼 추가
- 오답노트 페이지 나의 문제집 페이지와 디자인 비슷하게 수정
- 오답노트 페이지에 폴더 임시로 이식

## 기타사항 / 참고사항

- 하 힘들다...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a submit button to complete quizzes with validation feedback
  * Introduced folder-based filtering and folder list on the wrong-answer page

* **Bug Fixes**
  * True/false answers now display localized labels

* **Style**
  * Refined wrong-answer list item design with hover effects
  * Reorganized wrong-answer header/columns and improved spacing, shadows, and rounded corners

* **Chores**
  * Suppressed various debug/log outputs (no behavioral changes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->