### PR TITLE
FTSK-100: 이모지 -> lucide 변경

### DIFF
--- a/src/features/library/components/RightClickMenu/RightClickMenuItem.tsx
+++ b/src/features/library/components/RightClickMenu/RightClickMenuItem.tsx
@@ -40,10 +40,10 @@ interface RightClickMenuItemProps {
   onClick?: () => void;
   disabled?: boolean;
   icon?: LucideIcon;
-  title: string;
+  children?: React.ReactNode;
 }
 
-function RightClickMenuItem({ onClick, disabled, icon: Icon, title }: RightClickMenuItemProps) {
+function RightClickMenuItem({ onClick, disabled, icon: Icon, children }: RightClickMenuItemProps) {
   return (
     <StyledMenuItem onClick={disabled ? undefined : onClick} disabled={disabled}>
       {Icon && (
@@ -51,7 +51,7 @@ function RightClickMenuItem({ onClick, disabled, icon: Icon, title }: RightClick
           <Icon />
         </MenuIcon>
       )}
-      {title}
+      {children}
     </StyledMenuItem>
   );
 }

--- a/src/features/library/components/RightClickMenu/RightClickMenuItem.tsx
+++ b/src/features/library/components/RightClickMenu/RightClickMenuItem.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { type LucideIcon } from 'lucide-react';
 
 const StyledMenuItem = styled.li<{ disabled?: boolean }>`
   padding: 8px 16px;
@@ -28,19 +29,28 @@ const MenuIcon = styled.span`
   display: flex;
   align-items: center;
   justify-content: center;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
 `;
 
 interface RightClickMenuItemProps {
   onClick?: () => void;
   disabled?: boolean;
-  icon?: string;
+  icon?: LucideIcon;
   title: string;
 }
 
-function RightClickMenuItem({ onClick, disabled, icon, title }: RightClickMenuItemProps) {
+function RightClickMenuItem({ onClick, disabled, icon: Icon, title }: RightClickMenuItemProps) {
   return (
     <StyledMenuItem onClick={disabled ? undefined : onClick} disabled={disabled}>
-      {icon && <MenuIcon>{icon}</MenuIcon>}
+      {Icon && (
+        <MenuIcon>
+          <Icon />
+        </MenuIcon>
+      )}
       {title}
     </StyledMenuItem>
   );

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -17,7 +17,7 @@ import RightClickMenu from '@/features/library/components/RightClickMenu/RightCl
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import RightClickMenuDivider from '@/features/library/components/RightClickMenu/RightClickMenuDivider';
 import FolderList from '@/shared/components/FolderList';
-import { Pencil, Trash2, FileEdit, Folder } from 'lucide-react';
+import { Pencil, Trash2, FileEdit, Folder, Check, X } from 'lucide-react';
 
 interface Folder {
   id: number;
@@ -571,8 +571,12 @@ const Library = () => {
                           autoFocus
                         />
                         <div>
-                          <EditIconButton onClick={() => submitTitleEdit(item)}>✔️</EditIconButton>
-                          <EditIconButton onClick={() => setEditingItemId(null)}>❌</EditIconButton>
+                          <EditIconButton onClick={() => submitTitleEdit(item)}>
+                            <Check size={16} />
+                          </EditIconButton>
+                          <EditIconButton onClick={() => setEditingItemId(null)}>
+                            <X size={16} />
+                          </EditIconButton>
                         </div>
                       </TitleContainer>
                     ) : (

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -186,24 +186,26 @@ const EditIconButton = styled.button`
 `;
 
 const FolderSelectWrapper = styled.div`
-  padding: 8px 16px;
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
 `;
 
 const FolderSelectLabel = styled.span`
   font-size: 14px;
-  color: #333;
+  color: ${({ theme }) => theme.colors.text.default};
   white-space: nowrap;
+  flex-shrink: 0;
 `;
 
 const FolderSelect = styled.select`
   flex: 1;
-  padding: 6px 8px;
+  min-width: 0;
+  padding: 4px 8px;
   border: 1px solid ${({ theme }) => theme.colors.border.border1};
   border-radius: ${({ theme }) => theme.radius.radius2};
-  font-size: 14px;
+  font-size: 13px;
   background-color: ${({ theme }) => theme.colors.background.foreground};
   color: ${({ theme }) => theme.colors.text.default};
   cursor: pointer;
@@ -459,48 +461,53 @@ const Library = () => {
       <RightClickMenu isVisible={isVisibleMenu} setIsVisible={setIsVisibleMenu} point={mousePoint}>
         <RightClickMenuItem
           icon={Pencil}
-          title="문제집 이름 변경"
           onClick={handleMenuRename}
           disabled={selectedCell?.status !== 'COMPLETE'}
-        />
+        >
+          문제집 이름 변경
+        </RightClickMenuItem>
         <RightClickMenuItem
           icon={Trash2}
-          title="삭제"
           onClick={handleMenuDelete}
           disabled={selectedCell?.status !== 'COMPLETE'}
-        />
+        >
+          삭제
+        </RightClickMenuItem>
         <RightClickMenuDivider />
         {folders && folders.length > 0 && (
           <>
-            <FolderSelectWrapper>
-              <FolderSelectLabel>폴더 이동</FolderSelectLabel>
-              <FolderSelect
-                disabled={selectedCell?.status !== 'COMPLETE'}
-                defaultValue={selectedFolderId ?? ''}
-                onChange={(e) => {
-                  const targetFolderId = Number(e.target.value);
-                  if (targetFolderId !== selectedFolderId) {
-                    handleMenuMoveToFolder(targetFolderId);
-                  }
-                }}
-                onClick={(e) => e.stopPropagation()}
-              >
-                {folders.map((folder) => (
-                  <option key={folder.id} value={folder.id}>
-                    {folder.name}
-                  </option>
-                ))}
-              </FolderSelect>
-            </FolderSelectWrapper>
+            <RightClickMenuItem icon={Folder} disabled={selectedCell?.status !== 'COMPLETE'}>
+              <FolderSelectWrapper>
+                <FolderSelectLabel>폴더 이동</FolderSelectLabel>
+                <FolderSelect
+                  disabled={selectedCell?.status !== 'COMPLETE'}
+                  defaultValue={selectedFolderId ?? ''}
+                  onChange={(e) => {
+                    const targetFolderId = Number(e.target.value);
+                    if (targetFolderId !== selectedFolderId) {
+                      handleMenuMoveToFolder(targetFolderId);
+                    }
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {folders.map((folder) => (
+                    <option key={folder.id} value={folder.id}>
+                      {folder.name}
+                    </option>
+                  ))}
+                </FolderSelect>
+              </FolderSelectWrapper>
+            </RightClickMenuItem>
             <RightClickMenuDivider />
           </>
         )}
         <RightClickMenuItem
           icon={FileEdit}
-          title="문제집 풀기"
           onClick={handleMenuSolve}
           disabled={selectedCell?.status !== 'COMPLETE'}
-        />
+        >
+          문제집 풀기
+        </RightClickMenuItem>
       </RightClickMenu>
 
       <LibraryWrapper>

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -17,6 +17,7 @@ import RightClickMenu from '@/features/library/components/RightClickMenu/RightCl
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import RightClickMenuDivider from '@/features/library/components/RightClickMenu/RightClickMenuDivider';
 import FolderList from '@/shared/components/FolderList';
+import { Pencil, Trash2, FileEdit, Folder } from 'lucide-react';
 
 interface Folder {
   id: number;
@@ -457,13 +458,13 @@ const Library = () => {
     <Container>
       <RightClickMenu isVisible={isVisibleMenu} setIsVisible={setIsVisibleMenu} point={mousePoint}>
         <RightClickMenuItem
-          icon="✏️"
+          icon={Pencil}
           title="문제집 이름 변경"
           onClick={handleMenuRename}
           disabled={selectedCell?.status !== 'COMPLETE'}
         />
         <RightClickMenuItem
-          icon="❌"
+          icon={Trash2}
           title="삭제"
           onClick={handleMenuDelete}
           disabled={selectedCell?.status !== 'COMPLETE'}
@@ -472,7 +473,7 @@ const Library = () => {
         {folders && folders.length > 0 && (
           <>
             <FolderSelectWrapper>
-              <FolderSelectLabel>📁 폴더 이동</FolderSelectLabel>
+              <FolderSelectLabel>폴더 이동</FolderSelectLabel>
               <FolderSelect
                 disabled={selectedCell?.status !== 'COMPLETE'}
                 defaultValue={selectedFolderId ?? ''}
@@ -495,7 +496,7 @@ const Library = () => {
           </>
         )}
         <RightClickMenuItem
-          icon="📝"
+          icon={FileEdit}
           title="문제집 풀기"
           onClick={handleMenuSolve}
           disabled={selectedCell?.status !== 'COMPLETE'}

--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -5,7 +5,7 @@ import api from '@/shared/api/axiosClient';
 import RightClickMenu from '@/features/library/components/RightClickMenu/RightClickMenu';
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import { type MyQuestionSetsResponse } from '@/features/library/types/questionSetResponse';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Check, Pencil, Trash2, X } from 'lucide-react';
 
 interface Folder {
   id: number;
@@ -321,16 +321,18 @@ const FolderList = ({
       >
         <RightClickMenuItem
           icon={Pencil}
-          title="폴더 이름 변경"
           onClick={handleFolderMenuRename}
           disabled={selectedFolder?.id === ALL_FOLDER_ID}
-        />
+        >
+          폴더 이름 변경
+        </RightClickMenuItem>
         <RightClickMenuItem
           icon={Trash2}
-          title="폴더 삭제"
           onClick={handleFolderMenuDelete}
           disabled={selectedFolder?.id === ALL_FOLDER_ID}
-        />
+        >
+          폴더 삭제
+        </RightClickMenuItem>
       </RightClickMenu>
       <FolderContainer>
         {folders &&
@@ -352,7 +354,7 @@ const FolderList = ({
               >
                 {isEditingThisFolder ? (
                   <>
-                    📁{' '}
+                    {' '}
                     <FolderInput
                       value={editingFolderName}
                       onChange={(e) => setEditingFolderName(e.target.value)}
@@ -373,7 +375,7 @@ const FolderList = ({
                         submitFolderNameEdit(folder);
                       }}
                     >
-                      ✔️
+                      <Check size={16} />
                     </FolderActionButton>
                     <FolderActionButton
                       onClick={(e) => {
@@ -381,11 +383,11 @@ const FolderList = ({
                         setEditingFolderId(null);
                       }}
                     >
-                      ❌
+                      <X size={16} />
                     </FolderActionButton>
                   </>
                 ) : (
-                  <>📁 {folder.name}</>
+                  <>{folder.name}</>
                 )}
               </FolderTag>
             );

--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -5,7 +5,7 @@ import api from '@/shared/api/axiosClient';
 import RightClickMenu from '@/features/library/components/RightClickMenu/RightClickMenu';
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import { type MyQuestionSetsResponse } from '@/features/library/types/questionSetResponse';
-import { Check, Pencil, Trash2, X } from 'lucide-react';
+import { Check, Pencil, Trash2, X, Folder as FolderIcon, Plus } from 'lucide-react';
 
 interface Folder {
   id: number;
@@ -394,7 +394,7 @@ const FolderList = ({
           })}
         {isAddingFolder ? (
           <FolderInputContainer>
-            <span>📁</span>
+            <FolderIcon size={16} />
             <FolderInput
               value={newFolderName}
               onChange={(e) => setNewFolderName(e.target.value)}
@@ -409,11 +409,17 @@ const FolderList = ({
               placeholder="폴더 이름"
               autoFocus
             />
-            <FolderActionButton onClick={handleConfirmAddFolder}>✔️</FolderActionButton>
-            <FolderActionButton onClick={handleCancelAddFolder}>❌</FolderActionButton>
+            <FolderActionButton onClick={handleConfirmAddFolder}>
+              <Check size={16} />
+            </FolderActionButton>
+            <FolderActionButton onClick={handleCancelAddFolder}>
+              <X size={16} />
+            </FolderActionButton>
           </FolderInputContainer>
         ) : (
-          <AddFolderButton onClick={handleAddFolder}>➕</AddFolderButton>
+          <AddFolderButton onClick={handleAddFolder}>
+            <Plus size={16} />
+          </AddFolderButton>
         )}
       </FolderContainer>
     </>

--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -5,6 +5,7 @@ import api from '@/shared/api/axiosClient';
 import RightClickMenu from '@/features/library/components/RightClickMenu/RightClickMenu';
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import { type MyQuestionSetsResponse } from '@/features/library/types/questionSetResponse';
+import { Pencil, Trash2 } from 'lucide-react';
 
 interface Folder {
   id: number;
@@ -319,13 +320,13 @@ const FolderList = ({
         point={folderMousePoint}
       >
         <RightClickMenuItem
-          icon="✏️"
+          icon={Pencil}
           title="폴더 이름 변경"
           onClick={handleFolderMenuRename}
           disabled={selectedFolder?.id === ALL_FOLDER_ID}
         />
         <RightClickMenuItem
-          icon="❌"
+          icon={Trash2}
           title="폴더 삭제"
           onClick={handleFolderMenuDelete}
           disabled={selectedFolder?.id === ALL_FOLDER_ID}


### PR DESCRIPTION
## PR 설명

- 이모지를 lucide 아이콘으로 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced text/emoji labels with consistent Lucide icon buttons across library menus, folder lists, and editing actions.
  * Embedded folder selection and other controls directly into menu items for smoother interaction.

* **Style**
  * Unified icon sizing and spacing, improved alignment, full-width menu item behavior, and better click targets for accessibility.
* **Chore**
  * Added support for passing rich content as menu item children for flexible labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->