### PR TITLE
FTSK-101: (우클릭 액션) PENDING 상태에서만 비활성화

### DIFF
--- a/src/features/library/types/questionSetResponse.ts
+++ b/src/features/library/types/questionSetResponse.ts
@@ -2,6 +2,8 @@ export type DifficultyType = 'EASY' | 'MEDIUM' | 'HARD';
 
 export type QuestionType = 'MULTIPLE_CHOICE' | 'TRUE_FALSE' | 'SHORT_ANSWER';
 
+export type QuestionSetStatus = 'FAILED' | 'PENDING' | 'COMPLETE';
+
 export interface MyQuestionSetsResponse {
   questionSetId: number;
   title: string;
@@ -14,3 +16,7 @@ export interface MyQuestionSetsResponse {
   commonFolderId: number;
   commonFolderName: string;
 }
+
+export type QuestionSetContentType = MyQuestionSetsResponse & {
+  status: QuestionSetStatus;
+};

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -455,31 +455,33 @@ const Library = () => {
       item.title.toLowerCase().includes(debouncedSearchTerm.toLowerCase()),
     ) ?? [];
 
+  const isSelectedCellPending = selectedCell?.status === 'PENDING';
+
   return (
     <Container>
       <RightClickMenu isVisible={isVisibleMenu} setIsVisible={setIsVisibleMenu} point={mousePoint}>
         <RightClickMenuItem
           icon={Pencil}
           onClick={handleMenuRename}
-          disabled={selectedCell?.status === 'PENDING'}
+          disabled={isSelectedCellPending}
         >
           문제집 이름 변경
         </RightClickMenuItem>
         <RightClickMenuItem
           icon={Trash2}
           onClick={handleMenuDelete}
-          disabled={selectedCell?.status !== 'COMPLETE'}
+          disabled={isSelectedCellPending}
         >
           삭제
         </RightClickMenuItem>
         <RightClickMenuDivider />
         {folders && folders.length > 0 && (
           <>
-            <RightClickMenuItem icon={Folder} disabled={selectedCell?.status === 'PENDING'}>
+            <RightClickMenuItem icon={Folder} disabled={isSelectedCellPending}>
               <FolderSelectWrapper>
                 <FolderSelectLabel>폴더 이동</FolderSelectLabel>
                 <FolderSelect
-                  disabled={selectedCell?.status === 'PENDING'}
+                  disabled={isSelectedCellPending}
                   defaultValue={selectedFolderId ?? ''}
                   onChange={(e) => {
                     const targetFolderId = Number(e.target.value);
@@ -503,7 +505,7 @@ const Library = () => {
         <RightClickMenuItem
           icon={FileEdit}
           onClick={handleMenuSolve}
-          disabled={selectedCell?.status === 'PENDING'}
+          disabled={isSelectedCellPending}
         >
           문제집 풀기
         </RightClickMenuItem>

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -7,8 +7,9 @@ import api from '@/shared/api/axiosClient';
 import Spacer from '@/shared/components/Spacer';
 
 import {
-  type MyQuestionSetsResponse,
   type QuestionType,
+  type QuestionSetStatus,
+  type QuestionSetContentType,
 } from '@/features/library/types/questionSetResponse';
 
 import { useNavigate } from 'react-router-dom';
@@ -109,8 +110,6 @@ const HeaderCell = styled(ListCell)`
   font-weight: 600;
   font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
 `;
-
-type QuestionSetStatus = 'PENDING' | 'COMPLETE';
 
 const StatusCell = styled(ListCell)<{ status: QuestionSetStatus }>`
   font-weight: 500;
@@ -229,11 +228,11 @@ const TYPE_MAP: Record<QuestionType, string> = {
 };
 
 const STATUS_MAP: Record<QuestionSetStatus, string> = {
+  FAILED: '생성 실패',
   PENDING: '생성 중',
   COMPLETE: '생성완료',
 };
 
-type QuestionSetContentType = MyQuestionSetsResponse & { status: QuestionSetStatus };
 interface QuestionSets {
   content: QuestionSetContentType[];
   nextCursor: number;
@@ -460,13 +459,13 @@ const Library = () => {
           icon="✏️"
           title="문제집 이름 변경"
           onClick={handleMenuRename}
-          disabled={selectedCell?.status !== 'COMPLETE'}
+          disabled={selectedCell?.status === 'PENDING'}
         />
         <RightClickMenuItem
           icon="❌"
           title="삭제"
           onClick={handleMenuDelete}
-          disabled={selectedCell?.status !== 'COMPLETE'}
+          disabled={selectedCell?.status === 'PENDING'}
         />
         <RightClickMenuDivider />
         {folders && folders.length > 0 && (
@@ -474,7 +473,7 @@ const Library = () => {
             <FolderSelectWrapper>
               <FolderSelectLabel>📁 폴더 이동</FolderSelectLabel>
               <FolderSelect
-                disabled={selectedCell?.status !== 'COMPLETE'}
+                disabled={selectedCell?.status === 'PENDING'}
                 defaultValue={selectedFolderId ?? ''}
                 onChange={(e) => {
                   const targetFolderId = Number(e.target.value);
@@ -498,7 +497,7 @@ const Library = () => {
           icon="📝"
           title="문제집 풀기"
           onClick={handleMenuSolve}
-          disabled={selectedCell?.status !== 'COMPLETE'}
+          disabled={selectedCell?.status === 'PENDING'}
         />
       </RightClickMenu>
 

--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/shared/api/axiosClient';
 import RightClickMenu from '@/features/library/components/RightClickMenu/RightClickMenu';
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
-import { type MyQuestionSetsResponse } from '@/features/library/types/questionSetResponse';
+import { type QuestionSetContentType } from '@/features/library/types/questionSetResponse';
 
 interface Folder {
   id: number;
@@ -12,11 +12,6 @@ interface Folder {
   type: 'QUESTION_SET';
   sortOrder: number;
 }
-
-type QuestionSetStatus = 'PENDING' | 'COMPLETE';
-type QuestionSetContentType = MyQuestionSetsResponse & {
-  status: QuestionSetStatus;
-};
 
 interface FolderListProps {
   folders: Folder[] | undefined;

--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -5,6 +5,7 @@ import api from '@/shared/api/axiosClient';
 import RightClickMenu from '@/features/library/components/RightClickMenu/RightClickMenu';
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import { type QuestionSetContentType } from '@/features/library/types/questionSetResponse';
+import { Check, FolderIcon, Pencil, Plus, Trash2, X } from 'lucide-react';
 
 interface Folder {
   id: number;


### PR DESCRIPTION
## PR 설명

- 나의 문제집에서 PENDING 상태에서만 우클릭 메뉴들 비활성화 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of failed creation status for question sets.

* **Improvements**
  * Refined menu item availability (rename, delete, move, solve) to better reflect question set creation status during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->