### PR TITLE
FTSK-108: 전체 폴더 우클릭 비활성화

### DIFF
--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -17,15 +17,8 @@ import Spinner from '@/shared/components/Spinner';
 import RightClickMenu from '@/features/library/components/RightClickMenu/RightClickMenu';
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import RightClickMenuDivider from '@/features/library/components/RightClickMenu/RightClickMenuDivider';
-import FolderList from '@/shared/components/FolderList';
+import FolderList, { type Folder as FolderRes } from '@/shared/components/FolderList';
 import { Pencil, Trash2, FileEdit, Folder, Check, X } from 'lucide-react';
-
-interface Folder {
-  id: number;
-  name: string;
-  type: 'QUESTION_SET';
-  sortOrder: number;
-}
 
 const QUESTION_SET_TYPE = 'QUESTION_SET';
 
@@ -371,8 +364,12 @@ const Library = () => {
   const { data: folders, isPending: isFoldersPending } = useQuery({
     queryKey: ['folders'],
     queryFn: async () => {
-      const res = await api.get<Folder[]>(`/common-folders?type=${QUESTION_SET_TYPE}`);
-      return res.data.sort((a, b) => a.sortOrder - b.sortOrder);
+      const res = await api.get<FolderRes[]>(`/common-folders?type=${QUESTION_SET_TYPE}`);
+      return res.data.sort((a, b) => {
+        if (a.scope === 'ALL' && b.scope !== 'ALL') return -1;
+        if (a.scope !== 'ALL' && b.scope === 'ALL') return 1;
+        return a.sortOrder - b.sortOrder;
+      });
     },
   });
 

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { WrongNoteSetResponse } from '@/features/wrong/types/wrongNote';
 import { useState, useEffect } from 'react';
 import Spinner from '@/shared/components/Spinner';
-import FolderList from '@/shared/components/FolderList';
+import FolderList, { type Folder } from '@/shared/components/FolderList';
 
 // prettier 돌려줘
 const WrongWrapper = styled.div`
@@ -116,12 +116,6 @@ const WrongNoteListHeaderColumn = styled.span`
 // 폴더 관련 타입 + 인터페이스들
 const QUESTION_SET_TYPE = 'QUESTION_SET';
 const ALL_FOLDER_ID = 1;
-interface Folder {
-  id: number;
-  name: string;
-  type: 'QUESTION_SET';
-  sortOrder: number;
-}
 
 interface QuestionSetContent {
   questionSetId: number;

--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -7,10 +7,11 @@ import RightClickMenuItem from '@/features/library/components/RightClickMenu/Rig
 import { type QuestionSetContentType } from '@/features/library/types/questionSetResponse';
 import { Check, FolderIcon, Pencil, Plus, Trash2, X } from 'lucide-react';
 
-interface Folder {
+export interface Folder {
   id: number;
   name: string;
   type: 'QUESTION_SET';
+  scope: 'ALL' | 'CUSTOM';
   sortOrder: number;
 }
 
@@ -307,6 +308,8 @@ const FolderList = ({
     });
   };
 
+  const isDisabled = selectedFolder?.scope === 'ALL';
+
   return (
     <>
       <RightClickMenu
@@ -314,18 +317,10 @@ const FolderList = ({
         setIsVisible={setIsVisibleFolderMenu}
         point={folderMousePoint}
       >
-        <RightClickMenuItem
-          icon={Pencil}
-          onClick={handleFolderMenuRename}
-          disabled={selectedFolder?.id === ALL_FOLDER_ID}
-        >
+        <RightClickMenuItem icon={Pencil} onClick={handleFolderMenuRename} disabled={isDisabled}>
           폴더 이름 변경
         </RightClickMenuItem>
-        <RightClickMenuItem
-          icon={Trash2}
-          onClick={handleFolderMenuDelete}
-          disabled={selectedFolder?.id === ALL_FOLDER_ID}
-        >
+        <RightClickMenuItem icon={Trash2} onClick={handleFolderMenuDelete} disabled={isDisabled}>
           폴더 삭제
         </RightClickMenuItem>
       </RightClickMenu>


### PR DESCRIPTION
## PR 설명

- 전체 폴더 우클릭 비활성화 기능 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Improved folder ordering: system-managed (ALL) folders appear before custom ones, then by sort order.
  * Folder scope added across the UI to distinguish system-managed vs. custom folders.
  * Rename and delete actions are disabled for system-managed folders to prevent modifications.
* **Refactor**
  * Unified folder type usage across pages for consistent behavior and typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->