### PR TITLE
FTSK-109: 폴더 삭제시 문제집 갯수 문구 삭제

### DIFF
--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -281,15 +281,7 @@ const FolderList = ({
     setIsVisibleFolderMenu(false);
 
     try {
-      const response = await api.get<{ questionSetCount: number }>(
-        `/common-folders/${selectedFolder.id}/delete-warning`,
-      );
-
-      const questionSetCount = response.data.questionSetCount;
-      const confirmMessage =
-        questionSetCount > 0
-          ? `'${selectedFolder.name}' 폴더에 ${questionSetCount}개의 문제집이 있습니다.\n정말로 삭제하시겠습니까?`
-          : `'${selectedFolder.name}' 폴더를 정말 삭제하시겠습니까?`;
+      const confirmMessage = `'${selectedFolder.name}' 폴더를 정말 삭제하시겠습니까?`;
 
       if (window.confirm(confirmMessage)) {
         deleteFolderMutation.mutate(selectedFolder.id);


### PR DESCRIPTION
## PR 설명

- 이제 더 이상 폴더 삭제시 해당 폴더에 몇개의 문제집이 들어 있는지 표시하지 않습니다.

## 작업 상세 내용

- <작업 상세 내용>

## 기타사항 / 참고사항

- <기타사항 / 참고사항>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder deletion confirmation now displays a consistent message for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->