### PR TITLE
FTSK-113: 나의문제집 컬럼 변경

### DIFF
--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -64,7 +64,7 @@ const ListBox = styled.div`
   overflow: hidden;
 `;
 
-const ListRow = styled.div<{ isDragging?: boolean }>`
+const ListRow = styled.div<{ isDragging?: boolean; isDisabled?: boolean }>`
   display: grid;
   grid-template-columns: 3fr 1fr 1.2fr 1fr 1fr 1.2fr;
   align-items: center;
@@ -83,17 +83,17 @@ const ListRow = styled.div<{ isDragging?: boolean }>`
   }
 
   &:not(:first-of-type) {
-    cursor: grab;
+    cursor: ${({ isDisabled }) => (isDisabled ? 'not-allowed' : 'grab')};
   }
 
   &:not(:first-of-type):active {
-    cursor: grabbing;
+    cursor: ${({ isDisabled }) => (isDisabled ? 'not-allowed' : 'grabbing')};
   }
 `;
 
-const ListCell = styled.div<{ align?: 'left' | 'center' | 'right' }>`
+const ListCell = styled.div<{ align?: 'left' | 'center' | 'right'; isDisabled?: boolean }>`
   font-size: ${({ theme }) => theme.typography.body2Regular.fontSize};
-  color: ${({ theme }) => theme.colors.text.default};
+  color: ${({ isDisabled, theme }) => (isDisabled ? '#999' : theme.colors.text.default)};
   text-align: ${({ align }) => align || 'center'};
   white-space: nowrap;
   overflow: hidden;
@@ -107,6 +107,28 @@ const HeaderCell = styled(ListCell)`
 
 const StatusCell = styled(ListCell)<{ status: QuestionSetStatus }>`
   font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+`;
+
+const LoadingSpinner = styled.div`
+  border: 2px solid #f3f3f3;
+  border-top: 2px solid #666;
+  border-radius: 50%;
+  width: 14px;
+  height: 14px;
+  animation: spin 1s linear infinite;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
 `;
 
 const ActionButton = styled.button`
@@ -540,20 +562,23 @@ const Library = () => {
           </ListRow>
 
           {[...filteredQuestionSets]
+            .filter((item) => item.status !== 'FAILED')
             .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
             .map((item) => {
               const isEditing = editingItemId === item.questionSetId;
+              const isPending = item.status === 'PENDING';
 
               return (
                 <ListRow
                   key={item.questionSetId}
                   draggable={item.status === 'COMPLETE'}
                   isDragging={draggedItem?.questionSetId === item.questionSetId}
+                  isDisabled={isPending}
                   onDragStart={(e) => handleDragStart(e, item)}
                   onDragEnd={handleDragEnd}
                   onContextMenu={(e) => handleContextMenu(e, item)}
                 >
-                  <ListCell align="left">
+                  <ListCell align="left" isDisabled={isPending}>
                     {isEditing ? (
                       <TitleContainer>
                         <TitleEditInput
@@ -581,18 +606,21 @@ const Library = () => {
                     ) : (
                       <TitleContainer>
                         <TitleText title={item.title}>{item.title}</TitleText>
+                        {isPending && <LoadingSpinner />}
                       </TitleContainer>
                     )}
                   </ListCell>
-                  <ListCell>{item.questionCount}</ListCell>
-                  <ListCell>
+                  <ListCell isDisabled={isPending}>{item.questionCount}</ListCell>
+                  <ListCell isDisabled={isPending}>
                     {new Intl.DateTimeFormat('sv-SE').format(new Date(item.createdAt))}
                   </ListCell>
-                  <ListCell>{TYPE_MAP[item.questionType] ?? '생성 실패'}</ListCell>
-                  <StatusCell status={item.status}>
+                  <ListCell isDisabled={isPending}>
+                    {TYPE_MAP[item.questionType] ?? '생성 실패'}
+                  </ListCell>
+                  <StatusCell status={item.status} isDisabled={isPending}>
                     {STATUS_MAP[item.status] ?? '생성 실패'}
                   </StatusCell>
-                  <ListCell>
+                  <ListCell isDisabled={isPending}>
                     {item.status === 'COMPLETE' && (
                       <PrimaryButton onClick={() => handleSolveClick(item.questionSetId)}>
                         풀기

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -8,7 +8,6 @@ import Spacer from '@/shared/components/Spacer';
 
 import {
   type QuestionType,
-  type QuestionSetStatus,
   type QuestionSetContentType,
 } from '@/features/library/types/questionSetResponse';
 
@@ -18,6 +17,7 @@ import RightClickMenu from '@/features/library/components/RightClickMenu/RightCl
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import RightClickMenuDivider from '@/features/library/components/RightClickMenu/RightClickMenuDivider';
 import FolderList, { type Folder as FolderRes } from '@/shared/components/FolderList';
+import { getFolderColor } from '@/shared/constants/folderColors';
 import { Pencil, Trash2, FileEdit, Folder, Check, X } from 'lucide-react';
 
 const QUESTION_SET_TYPE = 'QUESTION_SET';
@@ -66,7 +66,7 @@ const ListBox = styled.div`
 
 const ListRow = styled.div<{ isDragging?: boolean; isDisabled?: boolean }>`
   display: grid;
-  grid-template-columns: 3fr 1fr 1.2fr 1fr 1fr 1.2fr;
+  grid-template-columns: 3fr 1fr 1.2fr 1fr 0.8fr 1.2fr;
   align-items: center;
   width: 100%;
   padding: 16px 24px;
@@ -105,13 +105,23 @@ const HeaderCell = styled(ListCell)`
   font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
 `;
 
-const StatusCell = styled(ListCell)<{ status: QuestionSetStatus }>`
-  font-weight: 500;
-  display: flex;
+const FolderCellContent = styled.div`
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 8px;
 `;
+
+const FolderColorDot = styled.span<{ color: string }>`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: ${({ color }) => color};
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
+  flex-shrink: 0;
+`;
+
+const DEFAULT_FOLDER_COLOR = '#d1d5db';
 
 const LoadingSpinner = styled.div`
   border: 2px solid #f3f3f3;
@@ -243,12 +253,6 @@ const TYPE_MAP: Record<QuestionType, string> = {
   MULTIPLE_CHOICE: '객관식',
   SHORT_ANSWER: '단답형',
   TRUE_FALSE: '참/거짓',
-};
-
-const STATUS_MAP: Record<QuestionSetStatus, string> = {
-  FAILED: '생성 실패',
-  PENDING: '생성 중',
-  COMPLETE: '생성완료',
 };
 
 interface QuestionSets {
@@ -557,7 +561,7 @@ const Library = () => {
             <HeaderCell>문제 수</HeaderCell>
             <HeaderCell>생성일</HeaderCell>
             <HeaderCell>유형</HeaderCell>
-            <HeaderCell>상태</HeaderCell>
+            <HeaderCell align="left">폴더</HeaderCell>
             <HeaderCell>문제풀기</HeaderCell>
           </ListRow>
 
@@ -617,9 +621,18 @@ const Library = () => {
                   <ListCell isDisabled={isPending}>
                     {TYPE_MAP[item.questionType] ?? '생성 실패'}
                   </ListCell>
-                  <StatusCell status={item.status} isDisabled={isPending}>
-                    {STATUS_MAP[item.status] ?? '생성 실패'}
-                  </StatusCell>
+                  <ListCell align="left" isDisabled={isPending}>
+                    <FolderCellContent>
+                      <FolderColorDot
+                        color={
+                          item.commonFolderId
+                            ? getFolderColor(item.commonFolderId).bg
+                            : DEFAULT_FOLDER_COLOR
+                        }
+                      />
+                      <span>{item.commonFolderName ?? '-'}</span>
+                    </FolderCellContent>
+                  </ListCell>
                   <ListCell isDisabled={isPending}>
                     {item.status === 'COMPLETE' && (
                       <PrimaryButton onClick={() => handleSolveClick(item.questionSetId)}>

--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -6,6 +6,7 @@ import RightClickMenu from '@/features/library/components/RightClickMenu/RightCl
 import RightClickMenuItem from '@/features/library/components/RightClickMenu/RightClickMenuItem';
 import { type QuestionSetContentType } from '@/features/library/types/questionSetResponse';
 import { Check, FolderIcon, Pencil, Plus, Trash2, X } from 'lucide-react';
+import { getFolderColor } from '@/shared/constants/folderColors';
 
 export interface Folder {
   id: number;
@@ -128,24 +129,6 @@ const FolderActionButton = styled.button`
     transform: scale(0.9);
   }
 `;
-
-const FOLDER_COLORS = [
-  { bg: '#3b82f6', hover: '#2563eb' },
-  { bg: '#10b981', hover: '#059669' },
-  { bg: '#8b5cf6', hover: '#7c3aed' },
-  { bg: '#f59e0b', hover: '#d97706' },
-  { bg: '#ec4899', hover: '#db2777' },
-  { bg: '#06b6d4', hover: '#0891b2' },
-  { bg: '#ef4444', hover: '#dc2626' },
-  { bg: '#6366f1', hover: '#4f46e5' },
-  { bg: '#14b8a6', hover: '#0d9488' },
-  { bg: '#f97316', hover: '#ea580c' },
-];
-
-const getFolderColor = (folderId: number) => {
-  const index = folderId % FOLDER_COLORS.length;
-  return FOLDER_COLORS[index];
-};
 
 const FolderList = ({
   folders,

--- a/src/shared/constants/folderColors.ts
+++ b/src/shared/constants/folderColors.ts
@@ -1,0 +1,17 @@
+export const FOLDER_COLORS = [
+  { bg: '#3b82f6', hover: '#2563eb' },
+  { bg: '#10b981', hover: '#059669' },
+  { bg: '#8b5cf6', hover: '#7c3aed' },
+  { bg: '#f59e0b', hover: '#d97706' },
+  { bg: '#ec4899', hover: '#db2777' },
+  { bg: '#06b6d4', hover: '#0891b2' },
+  { bg: '#ef4444', hover: '#dc2626' },
+  { bg: '#6366f1', hover: '#4f46e5' },
+  { bg: '#14b8a6', hover: '#0d9488' },
+  { bg: '#f97316', hover: '#ea580c' },
+];
+
+export const getFolderColor = (folderId: number) => {
+  const index = folderId % FOLDER_COLORS.length;
+  return FOLDER_COLORS[index];
+};


### PR DESCRIPTION
## PR 설명

- 나의 문제집 테이블의 컬럼을 변경했습니다.

- 상태 삭제 (PENDING이면 회색으로 처리)
- 폴더명 추가

## 작업 상세 내용

<img width="1029" height="390" alt="image" src="https://github.com/user-attachments/assets/a06668ca-e729-405d-9ce2-001a94b626aa" />


## 기타사항 / 참고사항

- <기타사항 / 참고사항>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual folder color indicators in the library for better organization identification.
  * Added loading spinners to indicate when items are processing.

* **Improvements**
  * Enhanced visual feedback with disabled state styling for unavailable items.
  * Failed items are now filtered from the library view for cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->