### PR TITLE
FTSK-116: 문제풀이 페이지 height가 고정적이지 않던 문제 해결, 뒤로가기 버튼 onClick수정, 1번문제와 10번 문제때 이전,  다음버튼 hidden

### DIFF
--- a/src/features/solve/components/SolveHeader.tsx
+++ b/src/features/solve/components/SolveHeader.tsx
@@ -88,9 +88,9 @@ function SolveHeader({ currentQuestionIndex, title, questionLength, questions }:
   return (
     <SolveHeaderWrapper>
       <BackBtnTitleWrapper>
-        <SolveHeaderBackBtn>
+        <SolveHeaderBackBtn onClick={() => navigate(-1)}>
           <ArrowLeft size={20} />
-          <SolveHeaderBackBtnTxt onClick={() => navigate(-1)}>돌아가기</SolveHeaderBackBtnTxt>
+          <SolveHeaderBackBtnTxt>돌아가기</SolveHeaderBackBtnTxt>
         </SolveHeaderBackBtn>
         <TitleDescriptionWrapper>
           <SolveTitle>{title}</SolveTitle>

--- a/src/features/solve/components/question-types/MultipleChoiceSolve.tsx
+++ b/src/features/solve/components/question-types/MultipleChoiceSolve.tsx
@@ -222,11 +222,24 @@ function MultipleChoiceSolve({
           </ExplanationBox>
         )}
         <QuestionNavigation>
-          <PrevButton onClick={goPrev} disabled={currentQuestionIndex === 1}>
+          <PrevButton
+            onClick={goPrev}
+            style={{
+              visibility: currentQuestionIndex === 1 ? 'hidden' : 'visible',
+              pointerEvents: currentQuestionIndex === 1 ? 'none' : 'auto',
+            }}
+          >
             <ArrowLeft size={20} />
             이전
           </PrevButton>
-          <NextButton onClick={goNext}>
+          <NextButton
+            onClick={goNext}
+            style={{
+              visibility:
+                currentQuestionIndex === questions.questions.length ? 'hidden' : 'visible',
+              pointerEvents: currentQuestionIndex === questions.questions.length ? 'none' : 'auto',
+            }}
+          >
             다음
             <ArrowRight size={20} />
           </NextButton>

--- a/src/features/solve/components/question-types/MultipleChoiceSolve.tsx
+++ b/src/features/solve/components/question-types/MultipleChoiceSolve.tsx
@@ -33,9 +33,16 @@ const QuestionWrapper = styled.div``;
 
 const QuestionStem = styled.p`
   margin: ${({ theme }) => theme.spacing.spacing8} 0;
+  min-height: 80px;
+  display: flex;
+  align-items: center;
 `;
 
-const OptionList = styled.div``;
+const OptionList = styled.div`
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+`;
 
 const OptionItem = styled.p<{ active?: boolean }>`
   cursor: pointer;

--- a/src/features/solve/components/question-types/ShortAnswerSolve.tsx
+++ b/src/features/solve/components/question-types/ShortAnswerSolve.tsx
@@ -224,11 +224,23 @@ function ShortAnswerSolve({
           </ExplanationBox>
         )}
         <QuestionNavigation>
-          <PrevButton onClick={goPrev} disabled={currentQuestionIndex === 1}>
+          <PrevButton 
+            onClick={goPrev} 
+            style={{ 
+              visibility: currentQuestionIndex === 1 ? 'hidden' : 'visible',
+              pointerEvents: currentQuestionIndex === 1 ? 'none' : 'auto'
+            }}
+          >
             <ArrowLeft size={20} />
             이전
           </PrevButton>
-          <NextButton onClick={goNext}>
+          <NextButton 
+            onClick={goNext}
+            style={{ 
+              visibility: currentQuestionIndex === questions.questions.length ? 'hidden' : 'visible',
+              pointerEvents: currentQuestionIndex === questions.questions.length ? 'none' : 'auto'
+            }}
+          >
             다음
             <ArrowRight size={20} />
           </NextButton>

--- a/src/features/solve/components/question-types/ShortAnswerSolve.tsx
+++ b/src/features/solve/components/question-types/ShortAnswerSolve.tsx
@@ -33,9 +33,16 @@ const QuestionWrapper = styled.div``;
 
 const QuestionStem = styled.p`
   margin: ${({ theme }) => theme.spacing.spacing8} 0;
+  min-height: 60px;
+  display: flex;
+  align-items: center;
 `;
 
-const OptionList = styled.div``;
+const OptionList = styled.div`
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+`;
 
 const OptionInput = styled.input`
   width: 100%;

--- a/src/features/solve/components/question-types/ShortAnswerSolve.tsx
+++ b/src/features/solve/components/question-types/ShortAnswerSolve.tsx
@@ -224,21 +224,22 @@ function ShortAnswerSolve({
           </ExplanationBox>
         )}
         <QuestionNavigation>
-          <PrevButton 
-            onClick={goPrev} 
-            style={{ 
+          <PrevButton
+            onClick={goPrev}
+            style={{
               visibility: currentQuestionIndex === 1 ? 'hidden' : 'visible',
-              pointerEvents: currentQuestionIndex === 1 ? 'none' : 'auto'
+              pointerEvents: currentQuestionIndex === 1 ? 'none' : 'auto',
             }}
           >
             <ArrowLeft size={20} />
             이전
           </PrevButton>
-          <NextButton 
+          <NextButton
             onClick={goNext}
-            style={{ 
-              visibility: currentQuestionIndex === questions.questions.length ? 'hidden' : 'visible',
-              pointerEvents: currentQuestionIndex === questions.questions.length ? 'none' : 'auto'
+            style={{
+              visibility:
+                currentQuestionIndex === questions.questions.length ? 'hidden' : 'visible',
+              pointerEvents: currentQuestionIndex === questions.questions.length ? 'none' : 'auto',
             }}
           >
             다음

--- a/src/features/solve/components/question-types/TrueFalseSolve.tsx
+++ b/src/features/solve/components/question-types/TrueFalseSolve.tsx
@@ -235,21 +235,22 @@ function TrueFalseSolve({
           </ExplanationBox>
         )}
         <QuestionNavigation>
-          <PrevButton 
-            onClick={goPrev} 
-            style={{ 
+          <PrevButton
+            onClick={goPrev}
+            style={{
               visibility: currentQuestionIndex === 1 ? 'hidden' : 'visible',
-              pointerEvents: currentQuestionIndex === 1 ? 'none' : 'auto'
+              pointerEvents: currentQuestionIndex === 1 ? 'none' : 'auto',
             }}
           >
             <ArrowLeft size={20} />
             이전
           </PrevButton>
-          <NextButton 
+          <NextButton
             onClick={goNext}
-            style={{ 
-              visibility: currentQuestionIndex === questions.questions.length ? 'hidden' : 'visible',
-              pointerEvents: currentQuestionIndex === questions.questions.length ? 'none' : 'auto'
+            style={{
+              visibility:
+                currentQuestionIndex === questions.questions.length ? 'hidden' : 'visible',
+              pointerEvents: currentQuestionIndex === questions.questions.length ? 'none' : 'auto',
             }}
           >
             다음

--- a/src/features/solve/components/question-types/TrueFalseSolve.tsx
+++ b/src/features/solve/components/question-types/TrueFalseSolve.tsx
@@ -235,11 +235,23 @@ function TrueFalseSolve({
           </ExplanationBox>
         )}
         <QuestionNavigation>
-          <PrevButton onClick={goPrev} disabled={currentQuestionIndex === 1}>
+          <PrevButton 
+            onClick={goPrev} 
+            style={{ 
+              visibility: currentQuestionIndex === 1 ? 'hidden' : 'visible',
+              pointerEvents: currentQuestionIndex === 1 ? 'none' : 'auto'
+            }}
+          >
             <ArrowLeft size={20} />
             이전
           </PrevButton>
-          <NextButton onClick={goNext}>
+          <NextButton 
+            onClick={goNext}
+            style={{ 
+              visibility: currentQuestionIndex === questions.questions.length ? 'hidden' : 'visible',
+              pointerEvents: currentQuestionIndex === questions.questions.length ? 'none' : 'auto'
+            }}
+          >
             다음
             <ArrowRight size={20} />
           </NextButton>

--- a/src/features/solve/components/question-types/TrueFalseSolve.tsx
+++ b/src/features/solve/components/question-types/TrueFalseSolve.tsx
@@ -33,9 +33,16 @@ const QuestionWrapper = styled.div``;
 
 const QuestionStem = styled.p`
   margin: ${({ theme }) => theme.spacing.spacing8} 0;
+  min-height: 60px;
+  display: flex;
+  align-items: center;
 `;
 
-const OptionList = styled.div``;
+const OptionList = styled.div`
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+`;
 
 const OptionItem = styled.p<{ active?: boolean }>`
   cursor: pointer;

--- a/src/shared/components/SideBar/SideBar.tsx
+++ b/src/shared/components/SideBar/SideBar.tsx
@@ -33,6 +33,8 @@ const SideBarWrapper = styled.nav<{ isOpen: boolean }>`
   z-index: 100;
   transition: transform 0.4s ease;
 
+  background-color: ${({ theme }) => theme.colors.gray.gray0};
+  
   @media (max-width: 1050px) {
     width: 100%;
     height: 60px;
@@ -40,9 +42,9 @@ const SideBarWrapper = styled.nav<{ isOpen: boolean }>`
     border-right: none;
     border-bottom: 1px solid ${({ theme }) => theme.colors.gray.gray4};
     flex-direction: row;
-    transform: translateY(0); /* 항상 보이도록 */
+    transform: translateY(0); 
     position: fixed;
-    background-color: white;
+    background-color: ${({ theme }) => theme.colors.gray.gray0};
   }
 `;
 

--- a/src/shared/components/SideBar/SideBar.tsx
+++ b/src/shared/components/SideBar/SideBar.tsx
@@ -34,7 +34,7 @@ const SideBarWrapper = styled.nav<{ isOpen: boolean }>`
   transition: transform 0.4s ease;
 
   background-color: ${({ theme }) => theme.colors.gray.gray0};
-  
+
   @media (max-width: 1050px) {
     width: 100%;
     height: 60px;
@@ -42,7 +42,7 @@ const SideBarWrapper = styled.nav<{ isOpen: boolean }>`
     border-right: none;
     border-bottom: 1px solid ${({ theme }) => theme.colors.gray.gray4};
     flex-direction: row;
-    transform: translateY(0); 
+    transform: translateY(0);
     position: fixed;
     background-color: ${({ theme }) => theme.colors.gray.gray0};
   }


### PR DESCRIPTION
## PR 설명

- 문제풀이 페이지 height가 고정적이지 않던 문제 해결, 뒤로가기 버튼 onClick수정, 1번문제와 10번 문제때 이전,  다음버튼 hidden

## 작업 상세 내용

- 문제풀이 페이지 height가 고정적이지 않던 문제 해결, 뒤로가기 버튼 onClick수정, 1번문제와 10번 문제때 이전,  다음버튼 hidden

## 기타사항 / 참고사항

- 네


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation button behavior to properly disable at quiz start and end
  * Corrected sidebar background color consistency across mobile and desktop views

* **Style**
  * Improved question content layout with better spacing and alignment
  * Enhanced navigation interactions for clearer user feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->