### PR TITLE
FTSK-119: 모바일 화면에서 나의 문제집과 문제풀이 리스트를 카드형태의 디자인으로 변경, 문제풀이 상태 디자인 변경

### DIFF
--- a/src/features/solve/components/ProgressCard.tsx
+++ b/src/features/solve/components/ProgressCard.tsx
@@ -20,42 +20,58 @@ const CardTitle = styled.h6`
   font-size: ${({ theme }) => theme.typography.label1Bold.fontSize};
   font-weight: ${({ theme }) => theme.typography.label1Bold.fontWeight};
   line-height: ${({ theme }) => theme.typography.label1Bold.lineHeight};
+  margin-bottom: ${({ theme }) => theme.spacing.spacing4};
+  padding-bottom: ${({ theme }) => theme.spacing.spacing3};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray.gray4};
 `;
 
 const ProgressStats = styled.div`
   display: flex;
   flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.spacing3};
+  margin-bottom: ${({ theme }) => theme.spacing.spacing5};
 `;
 
 const ProgressStatItem = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: ${({ theme }) => theme.spacing.spacing2};
+  padding: ${({ theme }) => theme.spacing.spacing2} ${({ theme }) => theme.spacing.spacing3};
+  background-color: ${({ theme }) => theme.colors.gray.gray1};
+  border-radius: ${({ theme }) => theme.radius.radius2};
 `;
 
 const ProgressStatLabel = styled.span`
-  font-size: ${({ theme }) => theme.typography.body1Regular.fontSize};
-  font-weight: ${({ theme }) => theme.typography.body1Regular.fontWeight};
-  line-height: ${({ theme }) => theme.typography.body1Regular.lineHeight};
-  color: ${({ theme }) => theme.colors.gray.gray8};
+  font-size: ${({ theme }) => theme.typography.body2Regular.fontSize};
+  font-weight: ${({ theme }) => theme.typography.body2Regular.fontWeight};
+  line-height: ${({ theme }) => theme.typography.body2Regular.lineHeight};
+  color: ${({ theme }) => theme.colors.gray.gray7};
 `;
 
 const ProgressStatValue = styled.span`
   font-size: ${({ theme }) => theme.typography.body1Regular.fontSize};
   font-weight: ${({ theme }) => theme.typography.body1Regular.fontWeight};
   line-height: ${({ theme }) => theme.typography.body1Regular.lineHeight};
-  color: ${({ theme }) => theme.colors.gray.gray8};
+  color: ${({ theme }) => theme.colors.gray.gray10};
 `;
 
 const SubmitBtn = styled.button`
-  font-size: ${({ theme }) => theme.typography.label1Regular.fontSize};
-  font-weight: ${({ theme }) => theme.typography.label1Regular.fontWeight};
-  line-height: ${({ theme }) => theme.typography.label1Regular.lineHeight};
+  font-size: ${({ theme }) => theme.typography.label1Bold.fontSize};
+  font-weight: ${({ theme }) => theme.typography.label1Bold.fontWeight};
+  line-height: ${({ theme }) => theme.typography.label1Bold.lineHeight};
   color: ${({ theme }) => theme.colors.gray.gray0};
   background-color: ${({ theme }) => theme.colors.semantic.primary};
-  padding: ${({ theme }) => theme.spacing.spacing2} ${({ theme }) => theme.spacing.spacing4};
+  padding: ${({ theme }) => theme.spacing.spacing3} ${({ theme }) => theme.spacing.spacing4};
   border-radius: ${({ theme }) => theme.radius.radius2};
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.green.green7};
+  }
+
+  &:active {
+    background-color: ${({ theme }) => theme.colors.green.green6};
+  }
 `;
 type ProgressCardProps = {
   questionLength: number;

--- a/src/features/wrong/components/WrongNoteListItem.tsx
+++ b/src/features/wrong/components/WrongNoteListItem.tsx
@@ -43,6 +43,8 @@ const WrongNoteFileName = styled.span`
   font-size: ${({ theme }) => theme.typography.label2Regular.fontSize};
   font-weight: ${({ theme }) => theme.typography.label2Regular.fontWeight};
   line-height: ${({ theme }) => theme.typography.label2Regular.lineHeight};
+  color: ${({ theme }) => theme.colors.gray.gray6};
+  margin-top: 4px;
 `;
 
 const WrongCount = styled.span`
@@ -101,9 +103,18 @@ const MobileInfoRow = styled.div`
 
   @media (max-width: 1050px) {
     display: flex;
-    gap: ${({ theme }) => theme.spacing.spacing4};
+    flex-wrap: wrap;
+    gap: ${({ theme }) => theme.spacing.spacing3};
     width: 100%;
+    font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
+    color: ${({ theme }) => theme.colors.gray.gray7};
   }
+`;
+
+const MobileInfoItem = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 `;
 
 interface WrongNoteListItemProps {
@@ -146,8 +157,8 @@ function WrongNoteListItem({ item }: WrongNoteListItemProps) {
       <WrongCount>{item.incorrectCount}개</WrongCount>
       <QuestionSetType>{displayType}</QuestionSetType>
       <MobileInfoRow>
-        <span>오답 수: {item.incorrectCount}개</span>
-        <span>유형: {displayType}</span>
+        <MobileInfoItem>오답 수: {item.incorrectCount}개</MobileInfoItem>
+        <MobileInfoItem>유형: {displayType}</MobileInfoItem>
       </MobileInfoRow>
       <RetryBtnWrapper>
         <RetryBtn onClick={handleReviewNavigate}>복습하기</RetryBtn>

--- a/src/features/wrong/components/WrongNoteListItem.tsx
+++ b/src/features/wrong/components/WrongNoteListItem.tsx
@@ -14,11 +14,23 @@ const WrongNoteListItemWrapper = styled.div`
   &:hover {
     background-color: ${({ theme }) => theme.colors.gray.gray2};
   }
+
+  @media (max-width: 1050px) {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: ${({ theme }) => theme.spacing.spacing3};
+    padding: ${({ theme }) => theme.spacing.spacing4};
+  }
 `;
 
 const WrongNoteInfoTitleWrapper = styled.div`
   display: flex;
   flex-direction: column;
+
+  @media (max-width: 1050px) {
+    width: 100%;
+  }
 `;
 
 const WrongNoteTitle = styled.span`
@@ -38,6 +50,11 @@ const WrongCount = styled.span`
   font-weight: ${({ theme }) => theme.typography.label2Regular.fontWeight};
   line-height: ${({ theme }) => theme.typography.label2Regular.lineHeight};
   text-align: center;
+
+  @media (max-width: 1050px) {
+    text-align: left;
+    display: none;
+  }
 `;
 
 const QuestionSetType = styled.span`
@@ -46,12 +63,22 @@ const QuestionSetType = styled.span`
   line-height: ${({ theme }) => theme.typography.label2Regular.lineHeight};
   border-radius: ${({ theme }) => theme.radius.radius2};
   text-align: center;
+
+  @media (max-width: 1050px) {
+    text-align: left;
+    display: none;
+  }
 `;
 
 const RetryBtnWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  @media (max-width: 1050px) {
+    width: 100%;
+    justify-content: stretch;
+  }
 `;
 const RetryBtn = styled.button`
   font-size: ${({ theme }) => theme.typography.label2Bold.fontSize};
@@ -63,6 +90,20 @@ const RetryBtn = styled.button`
   border-radius: ${({ theme }) => theme.radius.radius2};
   width: 100px;
   text-align: center;
+
+  @media (max-width: 1050px) {
+    width: 100%;
+  }
+`;
+
+const MobileInfoRow = styled.div`
+  display: none;
+
+  @media (max-width: 1050px) {
+    display: flex;
+    gap: ${({ theme }) => theme.spacing.spacing4};
+    width: 100%;
+  }
 `;
 
 interface WrongNoteListItemProps {
@@ -104,6 +145,10 @@ function WrongNoteListItem({ item }: WrongNoteListItemProps) {
       </WrongNoteInfoTitleWrapper>
       <WrongCount>{item.incorrectCount}개</WrongCount>
       <QuestionSetType>{displayType}</QuestionSetType>
+      <MobileInfoRow>
+        <span>오답 수: {item.incorrectCount}개</span>
+        <span>유형: {displayType}</span>
+      </MobileInfoRow>
       <RetryBtnWrapper>
         <RetryBtn onClick={handleReviewNavigate}>복습하기</RetryBtn>
       </RetryBtnWrapper>

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -95,6 +95,26 @@ const ListRow = styled.div<{ isDragging?: boolean; isDisabled?: boolean }>`
   &:not(:first-of-type):active {
     cursor: ${({ isDisabled }) => (isDisabled ? 'not-allowed' : 'grabbing')};
   }
+
+  @media (max-width: 1050px) {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: ${({ theme }) => theme.spacing.spacing3};
+    padding: ${({ theme }) => theme.spacing.spacing4};
+
+    &:first-of-type {
+      display: none; /* 헤더 숨김 */
+    }
+
+    &:not(:first-of-type) {
+      cursor: default;
+    }
+
+    &:not(:first-of-type):active {
+      cursor: default;
+    }
+  }
 `;
 
 const ListCell = styled.div<{ align?: 'left' | 'center' | 'right'; isDisabled?: boolean }>`
@@ -104,6 +124,12 @@ const ListCell = styled.div<{ align?: 'left' | 'center' | 'right'; isDisabled?: 
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  @media (max-width: 1050px) {
+    text-align: left;
+    white-space: normal;
+    width: 100%;
+  }
 `;
 
 const HeaderCell = styled(ListCell)`
@@ -169,6 +195,11 @@ const PrimaryButton = styled(ActionButton)`
   border-color: ${({ theme }) => theme.colors.semantic.primary};
   color: white;
   font-weight: 600;
+
+  @media (max-width: 1050px) {
+    width: 100%;
+    padding: 10px 16px;
+  }
 `;
 
 const TitleContainer = styled.div`
@@ -176,6 +207,10 @@ const TitleContainer = styled.div`
   align-items: center;
   gap: 8px;
   max-width: 100%;
+
+  @media (max-width: 1050px) {
+    width: 100%;
+  }
 `;
 
 const TitleText = styled.span`
@@ -261,6 +296,46 @@ const FolderSelect = styled.select`
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
+  }
+`;
+
+const MobileInfoRow = styled.div`
+  display: none;
+
+  @media (max-width: 1050px) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: ${({ theme }) => theme.spacing.spacing3};
+    width: 100%;
+    font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
+    color: ${({ theme }) => theme.colors.gray.gray7};
+  }
+`;
+
+const MobileInfoItem = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+const MobileFolderInfo = styled.div`
+  display: none;
+
+  @media (max-width: 1050px) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: ${({ theme }) => theme.spacing.spacing2};
+    background-color: ${({ theme }) => theme.colors.gray.gray1};
+    border-radius: ${({ theme }) => theme.radius.radius2};
+    font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
+  }
+`;
+
+const DesktopOnly = styled(ListCell)`
+  @media (max-width: 1050px) {
+    display: none;
   }
 `;
 
@@ -645,14 +720,16 @@ const Library = () => {
                       </div>
                     )}
                   </ListCell>
-                  <ListCell isDisabled={isPending}>{item.questionCount}</ListCell>
-                  <ListCell isDisabled={isPending}>
+
+                  {/* 데스크톱 전용 셀들 */}
+                  <DesktopOnly isDisabled={isPending}>{item.questionCount}</DesktopOnly>
+                  <DesktopOnly isDisabled={isPending}>
                     {new Intl.DateTimeFormat('sv-SE').format(new Date(item.createdAt))}
-                  </ListCell>
-                  <ListCell isDisabled={isPending}>
+                  </DesktopOnly>
+                  <DesktopOnly isDisabled={isPending}>
                     {TYPE_MAP[item.questionType] ?? '생성 실패'}
-                  </ListCell>
-                  <ListCell align="left" isDisabled={isPending}>
+                  </DesktopOnly>
+                  <DesktopOnly align="left" isDisabled={isPending}>
                     <FolderCellContent>
                       <FolderColorDot
                         color={
@@ -663,7 +740,30 @@ const Library = () => {
                       />
                       <span>{item.commonFolderName ?? '-'}</span>
                     </FolderCellContent>
-                  </ListCell>
+                  </DesktopOnly>
+
+                  {/* 모바일 전용 정보 */}
+                  <MobileInfoRow>
+                    <MobileInfoItem>문제 수: {item.questionCount}개</MobileInfoItem>
+                    <MobileInfoItem>
+                      유형: {TYPE_MAP[item.questionType] ?? '생성 실패'}
+                    </MobileInfoItem>
+                    <MobileInfoItem>
+                      생성일: {new Intl.DateTimeFormat('sv-SE').format(new Date(item.createdAt))}
+                    </MobileInfoItem>
+                  </MobileInfoRow>
+
+                  <MobileFolderInfo>
+                    <FolderColorDot
+                      color={
+                        item.commonFolderId
+                          ? getFolderColor(item.commonFolderId).bg
+                          : DEFAULT_FOLDER_COLOR
+                      }
+                    />
+                    <span>폴더: {item.commonFolderName ?? '-'}</span>
+                  </MobileFolderInfo>
+
                   <ListCell isDisabled={isPending}>
                     {item.status === 'COMPLETE' && (
                       <PrimaryButton onClick={() => handleSolveClick(item.questionSetId)}>

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -101,6 +101,10 @@ const WrongNoteListHeader = styled.div`
   width: 100%;
   padding: ${({ theme }) => theme.spacing.spacing4} ${({ theme }) => theme.spacing.spacing6};
   transition: background-color 0.2s ease-in-out;
+
+  @media (max-width: 1050px) {
+    display: none; /* 모바일에서 헤더 숨김 */
+  }
 `;
 
 const WrongNoteListHeaderColumn = styled.span`


### PR DESCRIPTION
## PR 설명

- 모바일 화면에서 나의 문제집과 문제풀이 리스트를 카드형태의 디자인으로 변경, 문제풀이 상태 디자인 변경

## 작업 상세 내용

- 모바일 화면에서 나의 문제집과 문제풀이 리스트를 카드형태의 디자인으로 변경, 문제풀이 상태 디자인 변경

## 기타사항 / 참고사항

- 하?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile responsiveness across multiple components
  * Cards and list items now adapt to vertical layouts on screens ≤1050px with optimized spacing
  * Desktop-specific headers and elements intelligently hide on smaller screens
  * Enhanced visual hierarchy and typography treatment on all screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->