### PR TITLE
FTSK-122: 풀이페이지에 맞는 pageheader출력하도록 수정, 토스트 메시지가 최대 1개만 보이도록 수정, 모바일 환경에서 SideBarHeader에 none을 줘서 로고부분 감춤

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,7 +23,12 @@ createRoot(document.getElementById('root')!).render(
         <ErrorBoundary>
           <App />
         </ErrorBoundary>
-        <ToastContainer position="top-right" hideProgressBar={true} closeOnClick={true} />
+        <ToastContainer
+          position="top-right"
+          hideProgressBar={true}
+          closeOnClick={true}
+          limit={1}
+        />
       </QueryClientProvider>
     </ChakraProvider>
   </BrowserRouter>,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,12 +23,7 @@ createRoot(document.getElementById('root')!).render(
         <ErrorBoundary>
           <App />
         </ErrorBoundary>
-        <ToastContainer
-          position="top-right"
-          hideProgressBar={true}
-          closeOnClick={true}
-          limit={1}
-        />
+        <ToastContainer position="top-right" hideProgressBar={true} closeOnClick={true} limit={1} />
       </QueryClientProvider>
     </ChakraProvider>
   </BrowserRouter>,

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -365,6 +365,7 @@ const Library = () => {
   const [selectedCell, setSelectedCell] = useState<QuestionSetContentType | null>(null);
   const [draggedItem, setDraggedItem] = useState<QuestionSetContentType | null>(null);
   const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
+  const [longPressTimer, setLongPressTimer] = useState<NodeJS.Timeout | null>(null);
 
   const [mousePoint, setMousePoint] = useState<{
     x: number;
@@ -383,6 +384,34 @@ const Library = () => {
     setSelectedCell(item);
     setIsVisibleMenu(true);
     setMousePoint({ x: e.clientX, y: e.clientY });
+  };
+
+  // 모바일 길게 누르기 이벤트 핸들러
+  const handleTouchStart = (
+    e: React.TouchEvent<HTMLDivElement>,
+    item: QuestionSetContentType,
+  ) => {
+    const touch = e.touches[0];
+    const timer = setTimeout(() => {
+      setSelectedCell(item);
+      setIsVisibleMenu(true);
+      setMousePoint({ x: touch.clientX, y: touch.clientY });
+    }, 500); // 500ms 길게 누르기
+    setLongPressTimer(timer);
+  };
+
+  const handleTouchEnd = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      setLongPressTimer(null);
+    }
+  };
+
+  const handleTouchMove = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      setLongPressTimer(null);
+    }
   };
 
   const updateTitleMutation = useMutation({
@@ -680,6 +709,9 @@ const Library = () => {
                   onDragStart={(e) => handleDragStart(e, item)}
                   onDragEnd={handleDragEnd}
                   onContextMenu={(e) => handleContextMenu(e, item)}
+                  onTouchStart={(e) => handleTouchStart(e, item)}
+                  onTouchEnd={handleTouchEnd}
+                  onTouchMove={handleTouchMove}
                 >
                   <ListCell align="left" isDisabled={isPending}>
                     {isEditing ? (

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -387,10 +387,7 @@ const Library = () => {
   };
 
   // 모바일 길게 누르기 이벤트 핸들러
-  const handleTouchStart = (
-    e: React.TouchEvent<HTMLDivElement>,
-    item: QuestionSetContentType,
-  ) => {
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>, item: QuestionSetContentType) => {
     const touch = e.touches[0];
     const timer = setTimeout(() => {
       setSelectedCell(item);

--- a/src/pages/Wrong.tsx
+++ b/src/pages/Wrong.tsx
@@ -111,7 +111,7 @@ const WrongNoteListHeaderColumn = styled.span`
   font-weight: 600;
   font-size: ${({ theme }) => theme.typography.body3Regular.fontSize};
 
-  &:not(:first-child) {
+  &:not(:first-of-type) {
     text-align: center;
   }
 `;

--- a/src/shared/components/FolderList.tsx
+++ b/src/shared/components/FolderList.tsx
@@ -148,6 +148,7 @@ const FolderList = ({
   const [selectedFolder, setSelectedFolder] = useState<Folder | null>(null);
   const [editingFolderId, setEditingFolderId] = useState<number | null>(null);
   const [editingFolderName, setEditingFolderName] = useState('');
+  const [longPressTimer, setLongPressTimer] = useState<NodeJS.Timeout | null>(null);
 
   const [folderMousePoint, setFolderMousePoint] = useState<{
     x: number;
@@ -166,6 +167,31 @@ const FolderList = ({
     setSelectedFolder(folder);
     setIsVisibleFolderMenu(true);
     setFolderMousePoint({ x: e.clientX, y: e.clientY });
+  };
+
+  // 모바일 길게 누르기 이벤트 핸들러
+  const handleFolderTouchStart = (e: React.TouchEvent<HTMLDivElement>, folder: Folder) => {
+    const touch = e.touches[0];
+    const timer = setTimeout(() => {
+      setSelectedFolder(folder);
+      setIsVisibleFolderMenu(true);
+      setFolderMousePoint({ x: touch.clientX, y: touch.clientY });
+    }, 500); // 500ms 길게 누르기
+    setLongPressTimer(timer);
+  };
+
+  const handleFolderTouchEnd = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      setLongPressTimer(null);
+    }
+  };
+
+  const handleFolderTouchMove = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      setLongPressTimer(null);
+    }
   };
 
   const createFolderMutation = useMutation({
@@ -319,6 +345,9 @@ const FolderList = ({
                 folderHoverColor={colors.hover}
                 onClick={() => onFolderSelect(folder.id)}
                 onContextMenu={(e) => handleFolderContextMenu(e, folder)}
+                onTouchStart={(e) => handleFolderTouchStart(e, folder)}
+                onTouchEnd={handleFolderTouchEnd}
+                onTouchMove={handleFolderTouchMove}
                 onDragOver={(e) => handleDragOver(e, folder.id)}
                 onDragLeave={handleDragLeave}
                 onDrop={(e) => handleDrop(e, folder)}

--- a/src/shared/components/PageHeader/PageHeader.tsx
+++ b/src/shared/components/PageHeader/PageHeader.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Sidebar } from 'lucide-react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 const PageHeaderWrapper = styled.header`
   width: 100%;
@@ -38,14 +38,17 @@ interface PageHeaderProps {
 
 function PageHeader({ isOpen, openSideBar }: PageHeaderProps) {
   const location = useLocation();
+  const [searchParams] = useSearchParams();
   const path = location.pathname;
+  const isReviewing = searchParams.get('isReviewing') === 'true';
 
   let title = '페이지';
 
   if (path.startsWith('/dashboard')) title = '대시보드';
   else if (path.startsWith('/create')) title = '문제집 생성';
-  else if (path.startsWith('/solve')) title = '문제 풀이';
-  else if (path.startsWith('/library')) title = '나의 문제집';
+  else if (path.startsWith('/solve')) {
+    title = isReviewing ? '오답노트 풀이' : '문제 풀이';
+  } else if (path.startsWith('/library')) title = '나의 문제집';
   else if (path.startsWith('/wrong')) title = '오답노트';
   else if (path.startsWith('/settings')) title = '설정';
   else if (path === '/') title = '문제집 생성';

--- a/src/shared/components/SideBar/SideBar.tsx
+++ b/src/shared/components/SideBar/SideBar.tsx
@@ -65,7 +65,7 @@ const SideBarHeader = styled.header`
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray.gray4};
 
   @media (max-width: 1050px) {
-    display: none; /* 모바일에서 헤더(로고) 숨김 */
+    display: none;
   }
 `;
 

--- a/src/shared/components/SideBar/SideBar.tsx
+++ b/src/shared/components/SideBar/SideBar.tsx
@@ -65,11 +65,7 @@ const SideBarHeader = styled.header`
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray.gray4};
 
   @media (max-width: 1050px) {
-    width: auto;
-    height: 100%;
-    border-bottom: none;
-    border-right: 1px solid ${({ theme }) => theme.colors.gray.gray4};
-    padding: ${({ theme }) => theme.spacing.spacing3};
+    display: none; /* 모바일에서 헤더(로고) 숨김 */
   }
 `;
 


### PR DESCRIPTION
## PR 설명

- 풀이페이지에 맞는 pageheader출력하도록 수정, 토스트 메시지가 최대 1개만 보이도록 수정, 모바일 환경에서 SideBarHeader에 none을 줘서 로고부분 감춤

## 작업 상세 내용

- 풀이페이지에 맞는 pageheader출력하도록 수정, 토스트 메시지가 최대 1개만 보이도록 수정, 모바일 환경에서 SideBarHeader에 none을 줘서 로고부분 감춤

## 기타사항 / 참고사항

- 엄ㅁㅁㅁㅁㅁ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile long-press support for list and folder items to access context menus
  * Query parameter support for displaying review-specific page titles

* **Bug Fixes**
  * Limited toast notifications to one at a time for improved UX
  * Fixed responsive sidebar visibility on smaller screens

* **Style**
  * Updated header alignment styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->